### PR TITLE
Add contribution template for GPU kernel dumps

### DIFF
--- a/dump_contribution.yml
+++ b/dump_contribution.yml
@@ -1,0 +1,63 @@
+name: SASS dump contribution
+description: Propose a dump of an existing kernel on a GPU architecture the maintainer does not own
+title: "[DUMP] sm_XX: kernel NN"
+labels: ["contribution: dump"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing a cross-architecture dump. Fill this in before doing the work so the maintainer can confirm compile flags and kernel choice.
+
+  - type: dropdown
+    id: sm_version
+    attributes:
+      label: Target SM version
+      options:
+        - sm_80 (A100)
+        - sm_86 (RTX 3090)
+        - sm_89 (RTX 4090)
+        - sm_90a (H100)
+        - sm_100a (B200)
+        - other
+    validations:
+      required: true
+
+  - type: input
+    id: gpu_model
+    attributes:
+      label: GPU model
+      placeholder: "NVIDIA A100-SXM4-80GB"
+    validations:
+      required: true
+
+  - type: input
+    id: cuda_version
+    attributes:
+      label: CUDA toolkit version
+      placeholder: "12.6"
+    validations:
+      required: true
+
+  - type: input
+    id: driver_version
+    attributes:
+      label: NVIDIA driver version
+      placeholder: "560.35.03"
+    validations:
+      required: true
+
+  - type: input
+    id: kernel_ref
+    attributes:
+      label: Which kernel chapter do you want to dump
+      placeholder: "01_vector_add"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any constraint on your side (time availability, access window, etc).
+    validations:
+      required: false


### PR DESCRIPTION
This YAML file proposes a structure for contributing a dump of an existing kernel on a GPU architecture. It includes fields for target SM version, GPU model, CUDA version, driver version, kernel reference, and additional context.

## Type of contribution

Check one:

* [ ] SASS dump for an architecture (Type A)
* [ ] New kernel study (Type B)
* [ ] Correction to existing content (Type B)
* [ ] Documentation or reference update (Type B)

## Linked issue

Closes #

## Architecture

SM version:

GPU model:

CUDA toolkit version:

Driver version:

## Reproducibility

Exact compile command:

```
# paste here
```

Commit hash of source compiled:

## Summary of changes

Briefly describe what this PR adds or changes.

## Observations versus hypotheses

Directly observed in the SASS or measured in NCU:

Inferred from observed evidence:

Hypothesis remaining to be validated by microbenchmark or variation:

## Checklist

* [ ] An issue was opened first and approved by the maintainer
* [ ] Dump metadata (GPU, driver, CUDA, compile command) is included where applicable
* [ ] No dashes used as bullet markers in markdown files
* [ ] Claims are tagged as observed, inferred, or hypothesis
* [ ] One kernel study, one dump, or one correction only in this PR
