### PR TITLE
Sync knowledge base and homepage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Branch naming:
 
 ## Style
 
-Technical content is written in English. Conclusions follow the structure of existing chapter conclusions: source, SASS section by section, observations, hypotheses, open questions. Cross-reference `FINDINGS.md`, `CONTROL_CODES.md`, and `OPCODE_MODIFIERS.md` when discussing patterns already covered there.
+Technical content is written in English. Conclusions follow the structure of existing chapter conclusions: source, SASS section by section, observations, hypotheses, open questions. Cross-reference `knowledge/FINDINGS.md`, `knowledge/SASS_INSTRUCTIONS_SM120.md`, and `knowledge/encoding/` when discussing patterns already covered there.
 
 ## PR workflow
 

--- a/README.md
+++ b/README.md
@@ -1,194 +1,193 @@
-# SASS King
+<p align="center">
+  <img src="assets/sass-king-logo.svg" alt="SASS King logo" width="220">
+</p>
 
-Systematic reverse engineering of NVIDIA SASS, with the goal of enabling kernel-level audits on compiled CUDA binaries. Starting with SM120 (consumer Blackwell, RTX 50 series), expanding to other architectures over time.
+<h1 align="center">SASS King</h1>
 
-The last systematic public work on SASS was Jia et al. (Citadel) on Volta and Turing in 2018. Nothing equivalent exists for Ampere, Hopper, or Blackwell. For SM120 specifically: zero. SASS King fills that gap.
+<p align="center">
+  <strong>Reverse engineering NVIDIA SASS from controlled kernels to production audits.</strong>
+</p>
 
-Each study pairs SASS reading (cuobjdump + gpuasm.com) with NCU profiling to correlate instructions with measured performance.
+<p align="center">
+  <a href="knowledge/README.md">Knowledge base</a> ·
+  <a href="knowledge/SASS_INSTRUCTIONS_SM120.md">SM120 instruction glossary</a> ·
+  <a href="knowledge/encoding/">Encoding notes</a> ·
+  <a href="tensor_cores/README.md">Tensor-core chapters</a> ·
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
 
-Full context: Part 1 — Reading NVIDIA SASS from First Principles
+<p align="center">
+  <img alt="Architecture" src="https://img.shields.io/badge/architecture-SM120%20%2F%20SM120a-0b6d55">
+  <img alt="Status" src="https://img.shields.io/badge/status-research%20knowledge%20base-f4c95d">
+  <img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue">
+</p>
 
-## Goal
+SASS King is a systematic reverse-engineering project for NVIDIA SASS, the native GPU instruction set emitted inside compiled CUDA binaries. The project starts with SM120 / SM120a consumer Blackwell hardware and expands toward a full cross-architecture ISA and pattern library over time.
 
-Build the tools, documentation, and pattern library that let a kernel engineer open a SASS dump and understand what the compiler did, why, and what can be improved at the source level.
+The goal is practical: help a kernel engineer open a SASS dump, recognize compiler patterns, identify performance-relevant structures, and connect the binary back to source-level optimization decisions.
 
-Concretely, the project works toward an audit tool that takes a cubin and produces an optimization report. The public side is the knowledge: patterns, observations, annotated kernels. That's what SASS King is.
+## Why It Exists
+
+The last broad public SASS reverse-engineering work comparable in spirit was Jia et al. on Volta and Turing in 2018. Ampere, Hopper, and Blackwell have changed the instruction mix substantially: async copy paths, tensor-core families, matrix load/store instructions, sparse and scaled MMA forms, and new uniform-register flows.
+
+SASS King fills that gap by combining controlled micro-kernels, raw SASS reading, runtime probes, and production-kernel audits.
+
+## Current State
+
+| Area | Status | Where |
+|---|---|---|
+| SM120 teaching kernels | Complete through kernels 01-12 | `01_vector_add/` to `12_register_spill/` |
+| Tensor-core studies | Complete through Kernel 25 | `tensor_cores/` |
+| Global findings | Active source of truth | `knowledge/FINDINGS.md` |
+| SM120 instruction glossary | Active, evidence-backed | `knowledge/SASS_INSTRUCTIONS_SM120.md` |
+| Encoding pilots | Started with `LDSM`, `STSM`, `QMMA` | `knowledge/encoding/` |
+| Pattern library | Next phase | `patterns/` |
+| Production audits | Planned | `production/` |
+
+## Start Here
+
+- New to the project: read the [knowledge base index](knowledge/README.md).
+- Want the current instruction map: read [SASS instructions on SM120 / SM120a](knowledge/SASS_INSTRUCTIONS_SM120.md).
+- Want the raw source of truth: read [findings](knowledge/FINDINGS.md).
+- Want tensor-core evidence: start with [tensor-core chapters](tensor_cores/README.md).
+- Want to contribute dumps or corrections: read [contributing](CONTRIBUTING.md).
+
+Full context for the first public writeup: [Part 1 - Reading NVIDIA SASS from First Principles](https://florianmattana.com/p/reading-nvidia-sass-from-first-principles).
 
 ## Methodology
 
-**Controlled variation.** Two kernels differ by exactly one variable (dtype, operand order, unroll factor, compilation flag). The SASS diff isolates the compiler decision. Microbenchmarks via `%clock` for latency measurement. Results are reproducible from the kernel sources in the repo.
+**Controlled variation.** Two kernels differ by exactly one variable: dtype, operand order, unroll factor, memory layout, or compilation target. The SASS diff isolates the compiler decision.
 
-**Strict claim tagging.** Every observation is tagged: [OBS] for measured facts, [INF] for logical deductions, [HYP] for speculation, [RES] when a hypothesis becomes confirmed or refuted, [GAP] for open questions documented honestly rather than papered over.
+**Strict claim tags.** Every technical claim uses a tag:
 
-**Top-down and bottom-up combined.** Top-down: pattern recognition on real kernels (which structures recur, which are anomalies). Bottom-up: microbenchmarks isolating single instructions or sequences. Each approach validates the other.
+| Tag | Meaning |
+|---|---|
+| `[OBS]` | Directly observed in a dump, log, runtime output, or profile. |
+| `[INF]` | Inferred from observed evidence. |
+| `[HYP]` | Plausible but not confirmed. |
+| `[RES]` | A prior hypothesis resolved by later evidence. |
+| `[GAP]` | Open question documented explicitly. |
+
+**Top-down and bottom-up together.** Micro-kernels isolate individual instructions and compiler decisions. Production-like kernels show which patterns matter in real code.
+
+## What Is Covered
+
+The first pass focuses on the SM120 tensor-core and memory pipeline:
+
+- `HMMA`, `QMMA`, `OMMA`
+- `LDSM`, `STSM`
+- `LDGSTS`, `LDGDEPBAR`, `DEPBAR`
+- `LDG`, `STG`, `LDS`, `STS`, `REDG`
+- `BRA`, `EXIT`, `BSSY`, `BSYNC`, `WARPSYNC`
+- `SHFL`, `VOTE`, `REDUX`
+- uniform-register flow: `S2UR`, `R2UR`, `UMOV`, `ULEA`, `LDCU`
+
+The project does not pretend the ISA is complete yet. The public glossary tracks what is observed and explained; deeper pages under `knowledge/encoding/` track families with enough evidence for matcher-style documentation.
 
 ## Roadmap
 
-### Phase 1 — Teaching kernels on SM120 (controlled variation)
+### Phase 1 - Teaching Kernels
 
-- [x] Part 1 — Kernels 01 to 04: baseline, FMA fusion, scoreboards, unroll cascade. [Read](https://florianmattana.com/p/reading-nvidia-sass-from-first-principles)
-- [x] Kernel 05 — Loop with small fixed trip count
-- [x] Kernel 06 — Shared memory scalar (LDS, STS, BAR.SYNC), runtime modulo CALL
-- [x] Kernel 07 — Shared memory patterns (bank conflicts, padding, multi-buffer)
-- [x] Kernel 08 — Vectorized global memory (LDG.E.128, LDG.E.ENL2.256, FP64)
-- [x] Kernel 09 — Warp primitives (SHFL.BFLY, VOTE, MATCH)
-- [x] Kernel 10 — Warp reduction patterns (REDUX, butterfly, lane-zero)
-- [x] Kernel 11 — Slowpath arithmetic (MUFU.RCP/LG2/EX2/RSQ, inline division, log2f, expf, sinf, sqrtf, Payne-Hanek)
-- [x] Kernel 12 — Register spill and local memory (STL, LDL, LDL.LU, STL.128, stack frame, R2UR)
+Kernels 01-12 establish baseline SASS concepts: FMA fusion, scoreboard behavior, loop lowering, shared memory, global memory, warp primitives, slow-path math, and local-memory spills.
 
-### Phase 2 - Teaching and tensor core kernels on SM120 (controlled variation)
+### Phase 2 - Tensor-Core And SM120 Coverage
 
-- [x] Kernel 13 — HMMA baseline (FP16, BF16, m16n8k16): opcode family, register allocation, accumulator chaining, serial latency model
-- [x] Kernel 14 — QMMA baseline FP8/FP6/FP4 (kind::f8f6f4, m16n8k32): new opcode family, dtype encoding decoded across 5 input dtypes, MMA-family wide invariants, serial latency model
-- [x] Kernel 15 - MMA narrow (FP6, FP4 standalone variants, mixed-precision combinations)
-- [x] Kernel 16 — FP4 peak (kind::mxf8f6f4 block-scaled, m16n8k64, scale factor encoding)
-- [x] Kernel 17 — ldmatrix and stmatrix (LDSM, .trans modifier, latency)
-- [x] Kernel 18 — Pipelined MMA tile (ldmatrix + MMA scoreboard interleaving, accumulator chains)
-- [x] Kernel 19 - Sparse MMA (sparsity metadata encoding)
-- [x] Kernel 20 - Control flow (back-edge BRA detection, loop detection, predication vs branching)
-- [x] Kernel 21 - Divergence and reconvergence (BSSY/BSYNC, warp-divergent branches, predicated arithmetic, WARPSYNC.ALL)
-- [ ] Kernel 22 - stmatrix / matrix store (STSM if present, fallback STS sequence if not present)
-- [ ] Kernel 23 - FP4 / FP6 fragment layout (E2M1, E3M2, E2M3 packing and runtime validation)
-- [ ] Kernel 24 - Production mini-GEMM audit (LDGSTS + LDSM + QMMA/OMMA + STG end-to-end)
+Kernels 13-25 cover the current SM120 tensor-core path:
 
-### Phase 3 gate
+| Kernel | Topic |
+|---|---|
+| 13 | HMMA baseline, register allocation, accumulator chaining |
+| 14 | QMMA FP8 / FP6 / FP4 baseline |
+| 15 | Narrow MMA variants |
+| 16 | FP4 peak and block-scaled OMMA/QMMA |
+| 17 | LDSM and matrix-load behavior |
+| 18 | Pipelined MMA tile and async copy staging |
+| 19 | Sparse MMA metadata |
+| 20 | Control flow and back-edge detection |
+| 21 | Divergence and reconvergence |
+| 22 | STSM matrix-store behavior |
+| 23 | FP4 / FP6 fragment layout probes |
+| 24 | Production mini-GEMM audit |
+| 25 | STSM epilogue layout and storeback semantics |
 
-Phase 3 does not start until the remaining SM120 coverage needed for production audits is complete.
+### Phase 3 - Pattern Library
 
-Required before Phase 3:
+Formalize recurring structures into reusable signatures:
 
-- [x] Kernel 20 - Control flow
-- [x] Kernel 21 - Divergence and reconvergence
-- [ ] Kernel 22 - stmatrix / matrix store
+- `LDGSTS -> DEPBAR -> LDSM -> MMA`
+- chained `HMMA` / `QMMA` / `OMMA`
+- `STSM -> BAR -> LDS -> STG`
+- warp reductions and cross-lane collectives
+- register-spill signatures
+- scalar and uniform control-flow patterns
 
-Strongly recommended before Phase 3:
+### Phase 4 - Production Audits
 
-- [ ] Kernel 23 - FP4 / FP6 fragment layout
-- [ ] Kernel 24 - Production mini-GEMM audit
+Apply the pattern library to real kernels from libraries such as FlashAttention, CUTLASS, xFormers, Transformer Engine, FlashInfer, llama.cpp / ggml, tinygrad, and related projects. The goal is representative coverage by algorithmic pattern, not one markdown file per kernel.
 
-Deferred and non-blocking for Phase 3:
+### Phase 5 - Audit Tool
 
-- [ ] Sparse QMMA / OMMA latency once hardware runtime is available
-- [ ] Exact `.SP` bit placement in opcode/control fields
-- [ ] Full control-code bit decoder
+Build a pipeline that takes a cubin, detects known patterns, and emits an optimization-oriented report.
 
-### Phase 3 — Pattern library
+### Phase 6 - Cross-Architecture
 
-Formalize patterns extracted from chapter studies and production kernels. Each pattern gets a machine-readable signature, a reference kernel, and annotated SASS.
+Replay the methodology on additional targets:
 
-Running target: 20-30 patterns in the first pass. Examples in scope:
-
-- Warp reduction (sum, max, min, and, or, xor)
-- Chain HMMA (FP16, BF16) / QMMA (FP8 variants) / OMMA (FP4 peak)
-- cp.async pipeline (2-stage, 3-stage)
-- LDSM fragment loading (x1/x2/x4, with and without transpose)
-- Online softmax chunk (FlashAttention-style)
-- Block scaling computation (UE8M0, UE4M3)
-- FP4 encoding cascade
-- Register spill signature and recovery patterns
-
-### Phase 4 — Library audits
-
-Real production kernels, annotated end to end using the pattern library. Targets below; kernel counts reflect what is available on gpuasm.com.
-
-| Library | Kernels | Status |
-|---|---|---|
-| flash_attn2 | 138 | Planned |
-| flash_attn4 | 49 | Planned |
-| cutlass (SM120a) | 113 | Planned |
-| cute-tutorial | 13 | Planned |
-| xformers | 36 | Planned |
-| transformer_engine | 109 | Planned |
-| flashinfer | 36 | Planned |
-| flashmla | 9 | Planned |
-| deepep | 2 | Planned |
-| llamacpp / ggml | 218 | Planned |
-| sglang | 14 | Planned |
-| llmc | 8 | Planned |
-| tinygrad | 12 | Planned |
-| nunchaku | 37 | Planned |
-| fouroversix | 57 | Planned |
-| bitsandbytes | 2 | Planned |
-| arcquant | 24 | Planned |
-| qerl | 6 | Planned |
-| sgemm | 60 | Planned |
-| quack | 83 | Planned |
-
-Prioritization will favor coverage diversity (different algorithmic patterns) over raw count. Not all 1000+ kernels will be audited individually; representative kernels per library are the goal.
-
-### Phase 5 — Audit tool
-
-A pipeline that takes a cubin, detects patterns via the public pattern library, and produces an optimization report. Scope and distribution to be finalized as the library matures.
-
-### Phase 6 — Cross-architecture
-
-Same studies replayed on:
-
-- [ ] SM80 (A100)
-- [ ] SM86 (RTX 3090) — gpuasm example corpus
-- [ ] SM89 (RTX 4090)
-- [ ] SM90a (H100)
-- [ ] SM100a (B200)
-
-Via direct hardware access, contributors, or public dumps. The methodology and pattern format transfer; architecture-specific data requires its own measurements.
-
-## Target architectures
-
-| Arch | GPU | Why |
+| Arch | Representative GPU | Why |
 |---|---|---|
 | SM80 | A100 | Datacenter Ampere baseline |
-| SM86 | RTX 3090 | Consumer Ampere, gpuasm example corpus |
-| SM89 | RTX 4090 | Most common consumer inference card |
-| SM90a | H100 | TMA, WGMMA, warp specialization, mbarrier, clusters |
+| SM86 | RTX 3090 | Consumer Ampere corpus |
+| SM89 | RTX 4090 | Common consumer inference card |
+| SM90a | H100 | TMA, WGMMA, warp specialization, clusters |
 | SM100a | B200 | tcgen05.mma, TMEM |
-| SM120 | RTX 5070 Ti/5090 | Hybrid SM90/SM100 ISA, mma.sync with mxf8f6f4 |
+| SM120 | RTX 5070 Ti / 5090 | Consumer Blackwell starting point |
 
-Work starts on SM120 (direct hardware access). Other architectures via public dumps and contributors.
+## Repository Map
 
-## Repository layout
+```text
+.
+├── 01_vector_add/ ... 12_register_spill/   # Phase 1 teaching kernels
+├── tensor_cores/                           # Phase 2 tensor-core studies
+├── knowledge/                              # Findings, glossary, encoding notes
+│   ├── FINDINGS.md
+│   ├── SASS_INSTRUCTIONS_SM120.md
+│   └── encoding/
+├── patterns/                               # Coming: formal pattern library
+├── production/                             # Coming: production-kernel audits
+└── guide/                                  # SASS reading guide material
+```
 
-- `01_vector_add/` to `12_register_spill/` — Phase 1 teaching kernels (basic SASS patterns, controlled variation)
-- `tensor_cores/` — Phase 2 tensor core kernels organized by chapter
-  - `13_hmma_fp16/` — HMMA opcode family baseline
-  - `14_qmma_fp8/` — QMMA opcode family baseline
-  - `15_mma_narrow/` - FP6, FP4, and mixed narrow QMMA variants
-  - `16_fp4_peak/` — OMMA, block-scaled FP4
-  - `17_ldmatrix/` — LDSM variants
-  - `18_pipelined_tile/` — cp.async pipeline
-  - `19_sparse_mma/` - sparse MMA metadata and sparse QMMA/OMMA forms
-  - `20_control_flow/` - control-flow lowering, unroll pragmas, back-edge detection
-  - `21_divergence_reconvergence/` - divergence/reconvergence, predication, BSSY/BSYNC, WARPSYNC.ALL
-  - `22_stmatrix/`, `23_fragment_layout/`, `24_production_mini_gemm/` - planned before Phase 3
-- `patterns/` (coming) — formalized pattern library
-- `production/` (coming) — production kernel audits
-- `FINDINGS.md` — running log of observations, hypotheses, and resolutions, organized by chapter, with cross-chapter summary of pipelines, invariants, canonical patterns, and open gaps
+Each chapter folder contains source kernels, compiled artifacts when relevant, SASS dumps when they are part of the validated evidence set, and a `conclusion<N>.md` writeup.
 
-Each chapter folder contains the kernel sources (.cu), compiled binaries, and a `conclusion<N>.md` writeup. SASS dumps (.sass) are reproducible from the binaries via `cuobjdump --dump-sass` and are not committed.
+## Tooling
 
-## Tools
+- `cuobjdump --dump-sass` for raw disassembly.
+- `gpuasm.com` for scoreboards, stalls, pressure, and dependency arrows.
+- Nsight Compute for profiling and stall attribution.
+- `%clock` microbenchmarks for instruction latency probes.
+- `nvcc -Xptxas -v` for register and spill metadata.
 
-- `cuobjdump --dump-sass` for raw disassembly
-- `gpuasm.com` for scoreboards, stalls, pressure, and dependency arrows
-- Nsight Compute (NCU) for per-kernel profiling, SASS-to-source mapping, and stall attribution
-- `nvcc -Xptxas -v` for register usage and spill warnings
+## Related Work
 
-## Related work
+- [redplait/denvdis](https://github.com/redplait/denvdis) for opcode tables, latency extraction, scheduling analysis, and cubin patching.
+- [kuterdinel.com/nv_isa](https://kuterdinel.com/nv_isa/) for a fuzzed ISA specification.
+- Jia et al. 2018, "Dissecting the NVIDIA Volta GPU Architecture via Microbenchmarking."
+- NVIDIA `cuda-binary-utilities` documentation.
 
-SASS King stands on the shoulders of several reverse engineering efforts and remains complementary to them.
-
-- [redplait/denvdis](https://github.com/redplait/denvdis) extracts opcode tables and latency data directly from ptxas and provides `dg.pl` for scheduling analysis and `ced` for cubin patching. Essential low-level tooling.
-- [kuterdinel.com/nv_isa](https://kuterdinel.com/nv_isa/) provides a fuzzed ISA specification for SM90a.
-- Jia et al. 2018, "Dissecting the NVIDIA Volta GPU Architecture via Microbenchmarking." Foundational methodology.
-- NVIDIA `cuda-binary-utilities` documentation, the official opcode list for Blackwell.
-
-At this stage SASS King operates at a different layer: algorithmic pattern recognition on production kernels, mapped to source-level optimization opportunities.
+SASS King operates at the algorithmic pattern layer: recognizing how compiled kernels are structured and connecting those structures to source-level optimization decisions.
 
 ## Contributing
 
-Contributions are welcome, especially dumps from hardware we don't have direct access to (A100, H100, RTX 4090, B200). See `CONTRIBUTING.md` for what's useful: raw SASS dumps with metadata, kernel studies following the controlled variation methodology, corrections to observations, or new pattern proposals.
+Contributions are welcome, especially:
 
-If you work on SASS-level tooling (redplait, kuterdinel, others), collaboration on complementary layers is welcome. Reach out via GitHub issues or at [florianmattana.com](https://florianmattana.com).
+- raw SASS dumps from hardware not directly available here;
+- controlled kernel studies that isolate one compiler decision;
+- corrections to existing observations;
+- new production-kernel pattern proposals;
+- cross-architecture comparisons.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the expected metadata and writing standard.
 
 ## Author
 
-Florian Mattana. [florianmattana.com](https://florianmattana.com).
+Florian Mattana. [florianmattana.com](https://florianmattana.com)

--- a/assets/sass-king-logo.svg
+++ b/assets/sass-king-logo.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-labelledby="title desc">
+  <title id="title">SASS King logo</title>
+  <desc id="desc">A circuit-board crown in emerald and gold.</desc>
+  <defs>
+    <linearGradient id="emerald" x1="170" y1="130" x2="850" y2="920" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0e8a62"/>
+      <stop offset="0.52" stop-color="#075843"/>
+      <stop offset="1" stop-color="#01332f"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="220" y1="160" x2="790" y2="860" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff1a8"/>
+      <stop offset="0.45" stop-color="#f4c95d"/>
+      <stop offset="1" stop-color="#c9972d"/>
+    </linearGradient>
+    <filter id="shadow" x="-15%" y="-15%" width="130%" height="130%">
+      <feDropShadow dx="0" dy="24" stdDeviation="22" flood-color="#001b17" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+
+  <rect width="1024" height="1024" rx="92" fill="#07100f"/>
+  <g opacity="0.16">
+    <path d="M0 128h1024M0 256h1024M0 384h1024M0 512h1024M0 640h1024M0 768h1024M0 896h1024M128 0v1024M256 0v1024M384 0v1024M512 0v1024M640 0v1024M768 0v1024M896 0v1024" stroke="#7b8a83" stroke-width="2"/>
+  </g>
+
+  <g filter="url(#shadow)">
+    <path fill="url(#emerald)" d="M210 808V580L99 299l219 171 85-206 109 164 109-164 85 206 219-171-111 281v228c-189 63-415 63-604 0Z"/>
+    <path fill="#0b473c" d="M210 808h604v-62c-196 36-408 36-604 0v62Z" opacity="0.72"/>
+    <path fill="#0b6d55" d="M512 133 645 389 512 566 379 389 512 133Z"/>
+    <path fill="#0f785b" d="m143 363 174 136 74 187H244L143 363Zm738 0L707 499l-74 187h147l101-323Z"/>
+    <path fill="#0d654f" d="m408 314 87 132-87 116-75-90 75-158Zm208 0-87 132 87 116 75-90-75-158Z"/>
+  </g>
+
+  <g fill="none" stroke="url(#gold)" stroke-linecap="square" stroke-linejoin="miter">
+    <path d="M512 184v272M512 456l-74 119M512 456l74 119M438 575h148M438 575l74 91 74-91" stroke-width="24"/>
+    <path d="m222 409 174 142M202 721c190-47 429-47 620 0M802 409 628 551" stroke-width="22"/>
+    <path d="M308 623v-70l-36-36M716 623v-70l36-36M264 664h78M682 664h78" stroke-width="18"/>
+    <path d="M330 738h150v58H330v-58Zm214 0h150v58H544v-58Z" stroke-width="16"/>
+    <path d="M512 666v72M512 796v66M468 862v-66M556 862v-66" stroke-width="14"/>
+    <path d="M246 758h52M726 758h52M246 798h52M726 798h52" stroke-width="12"/>
+  </g>
+
+  <g fill="none" stroke="#54c885" stroke-linecap="round" stroke-linejoin="round" opacity="0.88">
+    <path d="M325 487 365 377l68 82 44-8M699 487 659 377l-68 82-44-8" stroke-width="14"/>
+    <path d="M292 537v86l45 45M732 537v86l-45 45M396 492v90M628 492v90" stroke-width="12"/>
+    <path d="M444 812h-82l-58-38M580 812h82l58-38" stroke-width="10"/>
+    <path d="M452 356v96M572 356v96M410 718v-46h52M614 718v-46h-52" stroke-width="10"/>
+  </g>
+
+  <g fill="url(#gold)">
+    <circle cx="292" cy="536" r="14"/>
+    <circle cx="732" cy="536" r="14"/>
+    <circle cx="396" cy="492" r="12"/>
+    <circle cx="628" cy="492" r="12"/>
+    <circle cx="512" cy="864" r="12"/>
+    <circle cx="468" cy="864" r="10"/>
+    <circle cx="556" cy="864" r="10"/>
+    <circle cx="304" cy="774" r="10"/>
+    <circle cx="720" cy="774" r="10"/>
+  </g>
+</svg>

--- a/knowledge/FINDINGS.md
+++ b/knowledge/FINDINGS.md
@@ -1229,10 +1229,12 @@ Chapter 15 closes the remaining narrow-QMMA dtype combination that chapter 14 di
 * [RES] Chapter 15 operand-order asymmetry test resolved the control-code part: reversing E3M2/E2M3 mirrors the A/B dtype bits exactly. Value-layout asymmetry remains untested at runtime in this environment.
 
 ### Open gaps
-* [GAP] FP6 element packing inside the A/B uint32 fragments remains undocumented. 15f provides a raw-pattern probe source and SASS dump, but runtime data is blocked until the NVIDIA driver is available.
-* [GAP] FP4 E2M1 fragment layout remains unresolved from GAP-14d-1. 15g provides a raw-nibble probe source and SASS dump, but runtime data is blocked until the NVIDIA driver is available.
-* [GAP] Unscaled E2M1 QMMA latency is not measured. 15h compiles the intended N=16/32/64 chains, but runtime timing is blocked by the unavailable NVIDIA driver.
-* [GAP] Mixed FP6 E3M2 × E2M3 latency is not measured. 15i compiles the intended N=16/32/64 chains, but runtime timing is blocked by the unavailable NVIDIA driver.
+* [GAP] FP6 element packing inside the A/B uint32 fragments remains decode-unresolved. Chapter 23 adds first-pass SASS coverage and runtime smoke outputs for FP6 baseline, mixed, lane-pattern, and operand-order probes, but the full lane-to-value map is not decoded yet.
+* [GAP] FP4 E2M1 fragment layout remains decode-unresolved from GAP-14d-1. Chapter 23 adds first-pass SASS coverage and runtime smoke outputs for E2M1 baseline, lane-pattern, LDSM-fed, direct-register, K-boundary, register-boundary, and special-value probes, but the full lane-to-value map is not decoded yet.
+* [OBS] Unscaled E2M1 QMMA latency probes run on the host GPU: N=16 total 1074 cycles, N=32 total 1639 cycles, N=64 total 2737 cycles.
+* [INF] The unscaled E2M1 QMMA marginal latency from N=32 to N=64 is approximately 34.3 cycles per QMMA.
+* [OBS] Mixed FP6 E3M2 x E2M3 latency probes run on the host GPU: N=16 total 1075 cycles, N=32 total 1636 cycles, N=64 total 2743 cycles.
+* [INF] The mixed FP6 E3M2 x E2M3 marginal latency from N=32 to N=64 is approximately 34.6 cycles per QMMA.
 * [GAP] The SASS-level cause of the k=32 FP4 throughput gap versus k=64 block-scaled OMMA remains chapter 16's shape/family distinction until 15h can be run on hardware.
 
 ### New instructions observed in this chapter
@@ -1340,7 +1342,7 @@ The low byte of the opcode is a reliable family identifier.
 * `.UE4M3` suffix: scale dtype ue4m3 (full notation for fine-grained mode)
 * `.4X` suffix on OMMA: scale_vec::4X (finer granularity than default 2X)
 ### Implications for production kernel audit
-With chapters 13 (HMMA), 14 (QMMA), 16 (dense block-scaled), 17 (LDSM), 18 (cp.async pipeline), and 19 (sparse MMA), the repo documents the observed warp-level tensor-core opcode families emitted by `mma.sync` and `mma.sp` on SM120. [INF] This is sufficient to identify dense and sparse tensor-core instructions in production GEMM, FP4 quantized inference, and block-scaled attention dumps. [INF] After chapters 20 and 21, the repo also covers tested loop lowering and first-pass divergence/reconvergence patterns, but it is still not sufficient for a complete end-to-end audit because matrix-store behavior, FP4/FP6 fragment layout, runtime validation, and production mini-GEMM integration still have open gaps.
+With chapters 13 (HMMA), 14 (QMMA), 16 (dense block-scaled), 17 (LDSM), 18 (cp.async pipeline), 19 (sparse MMA), 20 (control flow), 21 (divergence/reconvergence), 22 (STSM), 23 (FP4/FP6 fragment-layout probes), and 24 (production mini-GEMM audit), the repo documents the observed warp-level tensor-core opcode families emitted by `mma.sync`, `mma.sp`, `ldmatrix`, and `stmatrix` on SM120, plus a first-pass end-to-end pipeline fixture. [INF] This is sufficient for first-pass identification of dense, sparse, block-scaled, matrix-load, matrix-store, async-copy, global-store, and reduction instructions in production dumps. [INF] It is still not sufficient for complete production epilogue auditing because full FP4/FP6 lane-to-value decode, STSM epilogue/storeback semantics, and audit-confidence qualification still have open gaps.
 ### Diagnostic workflow for block-scaled MMA in production
 When auditing a block-scaled SASS dump:
 1. Identify the MMA family via low byte: 0x3c = HMMA, 0x7a = QMMA, 0x7f = OMMA.
@@ -1459,7 +1461,7 @@ Chapter establishing the LDSM SASS opcode family — the realization of `ldmatri
 * [RES] Chain overhead ~0 for LDSM, vs ~310 for HMMA and ~510 for QMMA.
 ### Open gaps
 * [GAP] `.trans` variants x1 and x2 not compiled/verified (inferred only). Predictions: `LDSM.16.MT88` and `LDSM.16.MT88.2`.
-* [GAP] `stmatrix` (STSM?) not tested. PTX `stmatrix.sync.aligned.*` introduced in SM90. Might exist as a separate opcode on SM120, or fall back to STS sequence. Needs its own section.
+* [RES] `stmatrix` is covered by Chapter 22 for tested m8n8 b16 forms. Those forms lower to `STSM.16.M[T]88[.2|.4]`; scalar shared-store fallback remains `STS.128`.
 * [GAP] LDSM width > 4 not tested. The 2-bit width field value 3 is unused — probably reserved.
 * [GAP] LDSM with larger elements (e.g., `.b32` variant) not tested. The `.16` in the mnemonic suggests an element size field that could hold other values.
 * [GAP] LDSM combined with cp.async (LDGSTS) in a full pipelined tile not tested. Needs chapter 18 (pipelined tile).
@@ -1671,7 +1673,7 @@ When auditing a production SASS dump:
 ### Open gaps
 
 * [GAP] Runtime validity of metadata patterns `0xaaaaaaaa`, `0x55555555`, and `0xffffffff` is not measured because the local NVIDIA driver is unavailable.
-* [GAP] Sparse QMMA and sparse OMMA latency are not measured because runtime timing is blocked by the unavailable NVIDIA driver.
+* [GAP] Sparse QMMA and sparse OMMA latency are not measured. Chapter 19 establishes SASS forms, but a dedicated sparse latency run is still needed.
 * [GAP] Exact bit-level meaning of the sparse `.SP` modifier inside QMMA and OMMA opcode/control fields is not fully decoded.
 * [GAP] Selector semantics for all warp-level sparse families are not fully mapped. Selector `1` is rejected for the tested `kind::f8f6f4` form, but other shapes and legacy `mma.sp` forms were not exhaustively compiled.
 
@@ -1828,6 +1830,182 @@ When auditing a production SASS dump:
 
 ---
 
+## Kernel 22 stmatrix / matrix store
+
+* [OBS] Chapter 22 establishes SM120 matrix-store behavior for 12 controlled variants covering m8n8 b16 STSM x1/x2/x4, transposed STSM x1/x2/x4, scalar STS fallback, layout readback shapes, barrier/no-barrier dependency shapes, and HMMA-adjacent STSM.
+
+### Variants and outcomes
+
+* [OBS] 22a `stmatrix.sync.aligned.x1.m8n8.shared.b16` emits 32 instructions and `STSM.16.M88 [R7], R2`.
+* [OBS] 22b `stmatrix.sync.aligned.x2.m8n8.shared.b16` emits 32 instructions and `STSM.16.M88.2 [R0], R6`.
+* [OBS] 22c `stmatrix.sync.aligned.x4.m8n8.shared.b16` emits 32 instructions and `STSM.16.M88.4 [R0], R8`.
+* [OBS] 22d `stmatrix.sync.aligned.x1.trans.m8n8.shared.b16` emits 32 instructions and `STSM.16.MT88 [R7], R2`.
+* [OBS] 22e `stmatrix.sync.aligned.x2.trans.m8n8.shared.b16` emits 32 instructions and `STSM.16.MT88.2 [R0], R6`.
+* [OBS] 22f `stmatrix.sync.aligned.x4.trans.m8n8.shared.b16` emits 32 instructions and `STSM.16.MT88.4 [R0], R8`.
+* [OBS] 22g scalar shared-store fallback emits 32 instructions and `STS.128 [R0], R8`.
+* [OBS] 22h x4 layout readback emits 40 instructions, `STSM.16.M88.4`, `BAR.SYNC.DEFER_BLOCKING 0x0`, and `LDS.128`.
+* [OBS] 22i x4 transposed layout readback emits 40 instructions, `STSM.16.MT88.4`, `BAR.SYNC.DEFER_BLOCKING 0x0`, and `LDS.128`.
+* [OBS] 22j barrier visibility probe emits 32 instructions, `STSM.16.M88.4`, `BAR.SYNC.DEFER_BLOCKING 0x0`, and `LDS R7, [R6+UR4]`.
+* [OBS] 22k no-barrier same-thread probe emits 32 instructions with adjacent `STSM.16.M88.4 [R0], R8` and `LDS R7, [R0]`.
+* [OBS] 22l HMMA-adjacent STSM emits 40 instructions, `HMMA.16816.F32 R8, R4, R8, RZ`, and later `STSM.16.M88.4 [R0], R8`.
+
+### STSM family rules established
+
+* [RES] `stmatrix.sync.aligned.x{1,2,4}.m8n8.shared.b16` lowers to the SM120 SASS family `STSM.16.M88[.2|.4]`.
+* [RES] `stmatrix.sync.aligned.x{1,2,4}.trans.m8n8.shared.b16` lowers to the SM120 SASS family `STSM.16.MT88[.2|.4]`.
+* [OBS] The tested STSM instruction low opcode byte is `0x44`.
+* [OBS] Normal x1 and transposed x1 share the visible instruction word `0x0000000207007844`, while their printed second line differs: normal `0x010fe20000000000`, transposed `0x010fe20000004000`.
+* [OBS] Normal x4 and transposed x4 share the visible instruction word `0x0000000800007844`, while their printed second line differs: normal `0x010fe20000000200`, transposed `0x010fe20000004200`.
+* [INF] For the tested pairs, the transposed modifier is represented by a `0x4000` delta in the printed second line.
+* [OBS] The scalar fallback variant emits `STS.128`, not `STSM`.
+* [INF] Scalar shared stores may vectorize into `STS.128`, but they remain a different store family from matrix-store STSM.
+
+### Unsupported forms and runtime gaps
+
+* [OBS] The opt-in b8 probe attempts `stmatrix.sync.aligned.m16n8.x1.trans.shared.b8`, `.x2`, and `.x4`.
+* [OBS] ptxas rejects the opt-in b8 probe for `sm_120` with `Feature '.m16n8' not supported on .target 'sm_120'`.
+* [OBS] ptxas rejects the opt-in b8 probe for `sm_120` with `Feature 'stmatrix.b8' not supported on .target 'sm_120'`.
+* [RES] The tested SM120 target does not support the tested m16n8 b8 STSM PTX forms.
+* [OBS] Runtime smoke probes for normal and transposed x4 STSM run on the host GPU.
+* [OBS] 22h normal x4 first output words are `00001000 00001001 00001002 00001003 00001004 00001005 00001006 00001007`.
+* [OBS] 22i transposed x4 first output words are `10041000 100c1008 10141010 101c1018 00000000 00000000 00000000 00000000`.
+* [OBS] 22j barrier visibility first output words are `00001004 00001008 0000100c 00001010 00001014 00001018 0000101c 00001020`.
+* [OBS] 22k no-barrier same-thread first output words are `00001000 00001004 00001008 0000100c 00001010 00001014 00001018 0000101c`.
+* [GAP] Full STSM lane-to-shared layout semantics remain undecoded from the runtime outputs.
+* [GAP] STSM latency is not measured.
+* [GAP] STSM scoreboard and control-code fields are not decoded beyond the printed SASS/control annotations.
+* [GAP] A full production accumulator-to-shared epilogue remains unvalidated.
+
+---
+
+## Kernel 23 FP4 / FP6 fragment layout
+
+* [OBS] Chapter 23 compiles 22 controlled probes, 23a through 23v, for FP4 / FP6 fragment-layout use cases on SM120.
+* [OBS] The accepted probes require `nvcc -arch=compute_120a -code=sm_120a`, matching the `kind::f8f6f4`, `kind::mxf8f6f4`, and `kind::mxf4nvf4` requirements established in Chapters 14, 16, and 19.
+
+### Variants and outcomes
+
+* [OBS] 23a E2M1 x E2M1 emits 48 instructions and `QMMA.16832.F32.E2M1.E2M1`.
+* [OBS] 23b E3M2 x E3M2 emits 48 instructions and `QMMA.16832.F32.E3M2.E3M2`.
+* [OBS] 23c E2M3 x E2M3 emits 48 instructions and `QMMA.16832.F32.E2M3.E2M3`.
+* [OBS] 23d E3M2 x E2M3 emits 48 instructions and `QMMA.16832.F32.E3M2.E2M3`.
+* [OBS] 23e E2M3 x E3M2 emits 48 instructions and `QMMA.16832.F32.E2M3.E3M2`.
+* [OBS] 23f, 23g, and 23h lane-pattern probes emit the expected dense `QMMA.16832` dtype mnemonics for E2M1, E3M2, and E2M3.
+* [OBS] 23i scale-factor interaction emits `QMMA.SF.16832.F32.E4M3.E4M3.E8`.
+* [OBS] 23j LDSM-to-QMMA emits `LDSM.16.M88.2`, `LDSM.16.M88.4`, and later `QMMA.16832.F32.E2M1.E2M1`.
+* [OBS] 23k direct-register path emits `QMMA.16832.F32.E2M1.E2M1` without LDSM.
+* [OBS] 23l runtime-decode probe emits `QMMA.16832.F32.E2M1.E2M1` and runs on the host GPU with first output words `c1d80000 c1d80000 c3220000 c3220000`.
+* [OBS] 23m invalid-format probe attempts `kind::f8f6f4` with E2M1 x BF16 and is rejected by ptxas with `Unexpected instruction types specified for 'mma'`.
+* [OBS] 23n cross-reference probe emits `QMMA.16832.F32.E3M2.E2M3`, matching the Chapter 15 mixed-FP6 family.
+* [OBS] 23o unsigned/signed interpretation probe emits `QMMA.16832.F32.E2M1.E2M1`.
+* [OBS] 23p scale-vector probe emits `OMMA.SF.16864.F32.E2M1.E2M1.UE4M3.4X`.
+* [OBS] 23q metadata-independence probe emits `QMMA.SF.SP.16864.F32.E3M2.E2M1.E8`.
+* [OBS] 23r operand-order probe emits `QMMA.16832.F32.E3M2.E2M3`.
+* [OBS] 23s K-tile boundary probe emits 56 instructions and `QMMA.16832.F32.E2M1.E2M1`.
+* [OBS] 23t register-pair boundary probe emits `QMMA.16832.F32.E2M1.E2M1`.
+* [OBS] 23u zero / NaN / Inf bit-pattern probe emits `QMMA.16832.F32.E2M1.E2M1`.
+* [OBS] 23v shared-memory alignment probe emits offset `LDSM.16.M88.2`, offset `LDSM.16.M88.4`, and later `QMMA.16832.F32.E2M1.E2M1`.
+
+### Fragment-layout rules established
+
+* [RES] The tested dense FP4/FP6 source forms stay in the `QMMA.16832` family; the A and B dtypes are explicit in the SASS mnemonic.
+* [RES] Dense E2M1, E3M2, E2M3, and mixed E3M2/E2M3 forms share the tested low opcode byte `0x7a`.
+* [RES] LDSM-fed FP4 QMMA is structurally visible as an LDSM stage followed by QMMA, while direct-register FP4 QMMA has no LDSM stage.
+* [RES] Scale factors and sparse metadata remain explicit SASS operands in the tested `QMMA.SF`, `OMMA.SF`, and `QMMA.SF.SP` probes.
+* [INF] A production audit model should treat fragment data, scale factors, sparse metadata, and shared-memory fragment loads as separate channels.
+
+### Runtime gaps
+
+* [OBS] All accepted Chapter 23 runtime smoke probes execute on the host GPU after fixing the LDSM B-fragment shared-memory stride to 16 bytes.
+* [GAP] FP4/FP6 full lane-to-value mapping remains undecoded from the runtime outputs.
+* [GAP] E3M2 and E2M3 exact bit packing within each 32-bit source register remains unresolved without runtime decode.
+* [GAP] Special-value interpretation for zero, sign-bit, NaN-like, and Inf-like patterns remains unresolved without runtime decode.
+* [GAP] LDSM-fed QMMA correctness for packed FP4/FP6 values remains structural only until outputs are checked on hardware.
+
+---
+
+## Kernel 24 Production mini-GEMM audit
+
+* [OBS] Chapter 24 compiles 30 controlled probes, 24a through 24ad, for production-like mini-GEMM audit structure on SM120.
+* [OBS] The probes require `nvcc -arch=compute_120a -code=sm_120a`, matching the arch-conditional tensor-core forms established in Chapters 14, 16, 19, and 23.
+* [OBS] Runtime smoke execution succeeds on the host RTX 5070 Ti for all 30 variants.
+* [GAP] The chapter validates structural SASS signatures and launchability, not full numeric GEMM correctness.
+
+### Variants and outcomes
+
+* [OBS] 24a emits `HMMA.16816.F32` and `STG.E.128`.
+* [OBS] 24b emits `QMMA.16832.F32.E4M3.E4M3` and `STG.E.128`.
+* [OBS] 24c emits `QMMA.16832.F32.E2M1.E2M1` and `STG.E.128`.
+* [OBS] 24d emits `OMMA.SF.16864.F32.E2M1.E2M1.UE4M3.4X` and `STG.E.128`.
+* [OBS] 24e, 24f, 24t, and 24x emit production-like async staging: `LDGSTS`, `LDGDEPBAR`, `DEPBAR.LE`, `BAR`, `LDSM`, `HMMA`, and `STG`.
+* [OBS] 24g and 24q isolate LDSM order and shared-memory alignment before `HMMA`.
+* [OBS] 24h emits four chained `QMMA.16832.F32.E4M3.E4M3` instructions.
+* [OBS] 24i is a store-only epilogue baseline and emits `STG.E.128` with no MMA.
+* [OBS] 24j and 24k emit `STSM.16.M88.4` epilogue structure after QMMA.
+* [OBS] 24l and 24y cover bounded/vectorized `STG.E.128` epilogues after `HMMA`.
+* [OBS] 24m and 24n cover preserved and unrolled tile-loop HMMA structure.
+* [OBS] 24o emits predicated guarded HMMA plus `WARPSYNC.ALL`.
+* [OBS] 24p increases instruction count to 112 useful instructions while retaining `HMMA` and `STG`.
+* [OBS] 24r emits `QMMA.SP.16864.F32.E4M3.E4M3`.
+* [OBS] 24s emits `OMMA.SF.SP.168128.F32.E2M1.E2M1.UE4M3.4X`.
+* [OBS] 24u emits warp-level `HMMA` and no `WGMMA` or `TCGEN` mnemonics.
+* [OBS] 24v and 24w expose uniform-register and descriptor/address arithmetic paths feeding tensor-core work.
+* [OBS] 24z emits `REDG.E.ADD.F32.FTZ.RN.STRONG.GPU`, separating split-K style reduction from normal `STG.E.128`.
+* [OBS] 24aa loads scale operands with `LDG.E.CONSTANT` before `OMMA.SF...UE4M3.4X`.
+* [OBS] 24ab loads sparse metadata with `LDG.E.CONSTANT` before `QMMA.SP`.
+* [OBS] 24ac uses nontrivial stride parameters before `HMMA`.
+* [OBS] 24ad emits `BSSY.RECONVERGENT`, `BSYNC.RECONVERGENT`, and `BPT.TRAP` around the cold path.
+
+### Production audit rules established
+
+* [RES] A first-pass SM120 mini-GEMM audit should segment the dump into global-to-shared copy, async dependency wait, shared matrix load, tensor-core compute, epilogue, optional reduction, and cold/error paths.
+* [RES] Scale values and sparse metadata should be tracked as separate dependency channels from fragment data; Chapter 24 shows both channels feeding their MMA operands through visible loads.
+* [RES] Split-K or multi-CTA accumulation can be recognized separately from vectorized stores by looking for `REDG.E.ADD.F32...`.
+* [RES] The tested production-like SM120 path remains warp-level: `HMMA`, `QMMA`, `OMMA`, sparse modifiers, `LDSM`, `STSM`, `LDGSTS`, `DEPBAR`, and `STG`; no `WGMMA` or `TCGEN` appears.
+* [GAP] STSM lane-to-shared layout and accumulator storeback semantics remain Chapter 25 scope.
+
+---
+
+## Kernel 25 STSM epilogue layout and storeback semantics
+
+* [OBS] Chapter 25 compiles 25 accepted executable SASS probes and one b8 compatibility probe, 25a through 25z, for STSM epilogue/storeback behavior on SM120/SM120a.
+* [OBS] The accepted probes require `nvcc -arch=compute_120a -code=sm_120a` and runtime smoke execution succeeds on the host RTX 5070 Ti.
+* [OBS] The 25q compatibility probe compiles with plain `sm_120` and captures ptxas rejection for `.m16n8` and `stmatrix.b8`; the same source compiles for `sm_120a` and emits `STSM.8.MT168`, `STSM.8.MT168.2`, and `STSM.8.MT168.4`.
+* [GAP] Full lane-to-value semantic decode remains open over the captured runtime output words.
+
+### Variants and outcomes
+
+* [OBS] 25a, 25b, and 25c emit `STSM.16.M88`, `STSM.16.M88.2`, and `STSM.16.M88.4`.
+* [OBS] 25d, 25e, and 25f emit `STSM.16.MT88`, `STSM.16.MT88.2`, and `STSM.16.MT88.4`.
+* [OBS] 25g emits `HMMA.16816.F32` before `STSM.16.M88.4`.
+* [OBS] 25h emits `QMMA.16832.F32.E2M1.E2M1` before `STSM.16.M88.4`.
+* [OBS] 25i emits HMMA, STSM, `BAR.SYNC.DEFER_BLOCKING`, `LDS.128`, and `STG.E`.
+* [OBS] 25j emits `STS.128` rather than STSM, preserving the scalar/vector shared-store fallback distinction.
+* [OBS] 25k covers predicated tail storeback after STSM.
+* [OBS] 25l emits offset `STSM.16.M88.4 [R+0x20]` and offset `LDS.128`.
+* [OBS] 25m emits the normal barrier-visible sequence: STSM, `BAR.SYNC.DEFER_BLOCKING`, `LDS.128`.
+* [OBS] 25n emits adjacent STSM and `LDS` without `BAR.SYNC`, useful only as a same-thread/no-barrier contrast.
+* [OBS] 25o emits two `STSM.16.M88.4` stores and two `LDS.128` reloads for split accumulator storeback.
+* [OBS] 25p and 25z emit two `LDS.128` reloads and eight global stores for runtime layout decode tables.
+* [OBS] 25s emits `F2F.F16.F32` conversions before STSM.
+* [OBS] 25t emits `F2F.BF16.F32` conversions before STSM.
+* [OBS] 25u emits `OMMA.SF.16864.F32.E2M1.E2M1.UE4M3.4X` before STSM.
+* [OBS] 25v emits `QMMA.SP.16864.F32.E4M3.E4M3` before STSM.
+* [OBS] 25w emits noncontiguous global stores at 8-byte-spaced offsets.
+* [OBS] 25x keeps `STSM.16.M88.4` under strided shared addressing.
+* [OBS] 25y grows to 232 useful instructions under register-pressure arithmetic and still preserves STSM, barrier, shared reload, and global storeback.
+
+### Epilogue rules established
+
+* [RES] Cross-thread STSM storeback should be modeled as `STSM -> BAR -> LDS -> STG` in first-pass production audits.
+* [RES] Same-thread no-barrier STSM readback can compile, but Chapter 25 does not prove cross-thread visibility is safe without a barrier.
+* [RES] STS fallback is distinct from STSM: the tested scalar fallback emits `STS.128`.
+* [RES] Accumulator narrowing before STSM is visible as `F2F.F16.F32` or `F2F.BF16.F32`, separate from the STSM opcode itself.
+* [RES] HMMA, QMMA, OMMA, and sparse QMMA accumulator paths can feed visible STSM epilogues in the tested SM120a probes.
+* [RES] b8 STSM support is target-qualified: rejected for tested plain `sm_120`, accepted for tested `sm_120a` as `STSM.8.MT168`.
+
+---
+
 # Additions to the Cross chapter summary section
 
 ## Tensor-core cross-chapter summary
@@ -1836,35 +2014,41 @@ When auditing a production SASS dump:
 
 | Pipeline / role | SASS families observed | Evidence |
 |---|---|---|
-| Tensor core MMA | [OBS] `HMMA`, `QMMA`, `OMMA`, `QMMA.SP`, `QMMA.SF.SP`, `OMMA.SF.SP` | chapters 13, 14, 16, 19 |
-| Matrix load | [OBS] `LDSM.16.M[T]88[.N]` | chapter 17 |
-| Async global-to-shared copy | [OBS] `LDGSTS`, `LDGDEPBAR`, `DEPBAR.LE SB0, N` | chapter 18 |
+| Tensor core MMA | [OBS] `HMMA`, `QMMA`, `QMMA.SF`, `OMMA.SF`, `QMMA.SP`, `QMMA.SF.SP`, `OMMA.SF.SP` | chapters 13, 14, 16, 19, 23, 24 |
+| Matrix load | [OBS] `LDSM.16.M[T]88[.N]` | chapters 17, 24 |
+| Matrix store | [OBS] `STSM.16.M[T]88[.2|.4]`, `STSM.8.MT168` on tested `sm_120a` b8 form | chapters 22, 24, 25 |
+| Async global-to-shared copy | [OBS] `LDGSTS`, `LDGDEPBAR`, `DEPBAR.LE SB0, N` | chapters 18, 24 |
+| Global epilogue/reduction | [OBS] `STG.E.128`, `REDG.E.ADD.F32...` | chapter 24 |
 
 ### Architectural invariants
 
 * [OBS] Dense HMMA, dense QMMA, dense OMMA, and tested sparse QMMA/OMMA forms are warp-level instructions on SM120. The SASS contains one instruction executed by the warp, with fragment operands distributed across the 32 participating lanes.
-* [OBS] No `wgmma.mma_async` or `tcgen05.mma` appears in the SM120 dumps studied through chapter 19.
+* [OBS] No `wgmma.mma_async` or `tcgen05.mma` appears in the SM120 dumps studied through chapter 24.
 * [OBS] Tensor-core family selection is visible in the mnemonic and low opcode byte: `HMMA` low byte `0x3c`, `QMMA` low byte `0x7a`, and `OMMA` low byte `0x7f`.
 * [INF] Sparse tensor-core forms are modifiers on the dense QMMA/OMMA families for the tested SM120 forms, because `QMMA.SP` and `QMMA.SF.SP` keep low byte `0x7a`, while `OMMA.SF.SP` keeps low byte `0x7f`.
 * [GAP] Non-TN MMA layouts are not systematically tested across all SM120 MMA families.
-* [GAP] Matrix-store behavior remains untested. `stmatrix` / STSM is now a required pre-Phase-3 chapter.
+* [RES] Matrix-store behavior for tested m8n8 b16 forms is covered by Chapter 22.
 
 ### Canonical tensor-core tile pattern
 
 ```text
-LDGSTS tile[N+1]                    [OBS] chapter 18, optional for pipelined kernels
-LDGDEPBAR / DEPBAR.LE SB0, N         [OBS] chapter 18
-BAR.SYNC                             [OBS] chapter 18
-LDSM B fragment                      [OBS] chapters 17, 18
-LDSM A fragment                      [OBS] chapters 17, 18
-HMMA / QMMA / OMMA / sparse variant   [OBS] chapters 13, 14, 16, 19
-accumulator chain via D == C          [OBS] chapters 13, 14, 16, 19
-STG epilogue                          [OBS] chapters 13, 14, 16, 19
+LDGSTS tile[N+1]                     [OBS] chapters 18, 24, optional for pipelined kernels
+LDGDEPBAR / DEPBAR.LE SB0, N         [OBS] chapters 18, 24
+BAR.SYNC                             [OBS] chapters 18, 24
+LDSM B fragment                      [OBS] chapters 17, 18, 24
+LDSM A fragment                      [OBS] chapters 17, 18, 24
+HMMA / QMMA / OMMA / sparse variant  [OBS] chapters 13, 14, 16, 19, 24
+accumulator chain via D == C         [OBS] chapters 13, 14, 16, 19, 24
+STSM optional shared epilogue        [OBS] chapters 22, 24
+STG / REDG epilogue                  [OBS] chapter 24
 ```
 
-* [OBS] Chapters 17 and 18 show ptxas emits LDSM B before LDSM A in tested tensor-core tiles.
+* [OBS] Chapters 17, 18, and 24 show ptxas emits LDSM B before LDSM A in tested tensor-core tiles.
 * [OBS] Chapters 13, 14, 16, and 19 show chained MMA forms colocate D and C registers after the first MMA in the chain.
-* [GAP] The store-back side of matrix fragments through `stmatrix` is not covered by the chapters completed so far.
+* [OBS] Chapter 22 adds the tested matrix-store side through `STSM.16.M[T]88[.2|.4]`.
+* [OBS] Chapter 24 adds a first-pass full production-like pipeline fixture with async copy, LDSM, MMA, optional STSM, STG, and reduction.
+* [OBS] Chapter 25 adds isolated STSM epilogue/storeback probes, including narrowing conversions, shared reload, STG storeback, and fallback comparison.
+* [GAP] Full lane-to-value semantic decode for STSM remains open over the captured runtime output words.
 
 ### Arithmetic operator compilation rules
 
@@ -1878,6 +2062,8 @@ STG epilogue                          [OBS] chapters 13, 14, 16, 19
 | [OBS] `mma.sp::ordered_metadata...kind::mxf8f6f4.block_scale...` | [OBS] `QMMA.SF.SP.16864.<acc>.<A>.<B>.<scale>` |
 | [OBS] `mma.sp::ordered_metadata...kind::mxf4nvf4.block_scale...` | [OBS] `OMMA.SF.SP.168128.<acc>.<A>.<B>.<scale>[.<scale_vec>]` |
 | [OBS] `ldmatrix.sync.aligned.x{1,2,4}.shared.b16` | [OBS] `LDSM.16.M88[.N]` |
+| [OBS] `stmatrix.sync.aligned.x{1,2,4}.m8n8.shared.b16` | [OBS] `STSM.16.M88[.2|.4]` |
+| [OBS] `stmatrix.sync.aligned.x{1,2,4}.trans.m8n8.shared.b16` | [OBS] `STSM.16.MT88[.2|.4]` |
 
 ### Cost rules established so far
 
@@ -1885,7 +2071,8 @@ STG epilogue                          [OBS] chapters 13, 14, 16, 19
 * [RES] QMMA.16832.F32 serial dependency-chain latency is approximately 35 cycles per MMA on SM120.
 * [RES] OMMA.SF.16864.F32 serial dependency-chain latency is approximately 29 cycles per MMA on SM120.
 * [RES] LDSM serial latency is approximately 33 cycles on SM120.
-* [GAP] Sparse QMMA/OMMA serial latency is not measured because runtime timing is blocked by the unavailable driver.
+* [GAP] STSM latency is not measured.
+* [GAP] Sparse QMMA/OMMA serial latency is not measured.
 * [GAP] Scale factor value effects are not measured beyond unity-scale probes.
 * [GAP] Sparse metadata load overhead at runtime is not measured.
 
@@ -1895,7 +2082,9 @@ STG epilogue                          [OBS] chapters 13, 14, 16, 19
 * [OBS] `QMMA.16832` identifies dense `kind::f8f6f4` non-scaled MMA on SM120.
 * [OBS] `.SF` on QMMA or OMMA identifies block scaling on SM120.
 * [OBS] `.SP` on QMMA or OMMA identifies sparse `mma.sp::ordered_metadata` on SM120.
+* [OBS] For tested Chapter 23 forms, FP4/FP6 A and B dtypes are explicit in the `QMMA`, `QMMA.SF`, `OMMA.SF`, and `QMMA.SF.SP` mnemonics.
 * [OBS] `LDSM` identifies matrix-fragment loads from shared memory.
+* [OBS] `STSM` identifies matrix-fragment stores to shared memory.
 * [OBS] `LDGSTS` plus `LDGDEPBAR` plus `DEPBAR.LE SB0, N` identifies cp.async staging.
 
 ## Opcode operand semantics
@@ -1905,18 +2094,21 @@ STG epilogue                          [OBS] chapters 13, 14, 16, 19
 * [OBS] Sparse non-scaled QMMA adds metadata register and selector immediate after C.
 * [OBS] Sparse block-scaled QMMA/OMMA operand order after C is metadata register, scale register, `URZ`, selector immediate.
 * [OBS] LDSM operand order is destination register base and shared-memory address operand.
-* [GAP] STSM operand semantics are not observed.
+* [OBS] STSM operand order is shared-memory address operand followed by source register base for the tested m8n8 b16 forms.
+* [GAP] Full lane-to-shared layout semantics for STSM are not runtime-validated.
 
 ## Global diagnostic workflow for tensor-core dumps
 
 * [OBS] Grep for `HMMA`, `QMMA`, `OMMA`, `QMMA.SP`, `QMMA.SF.SP`, and `OMMA.SF.SP` to locate tensor-core compute.
 * [OBS] Grep for `LDSM` to locate shared-memory fragment loading.
+* [OBS] Grep for `STSM` to locate shared-memory fragment stores.
 * [OBS] Grep for `LDGSTS`, `LDGDEPBAR`, and `DEPBAR.LE` to locate cp.async staging.
 * [OBS] Read shape and dtype directly from the MMA mnemonic for observed SM120 tensor-core families.
 * [OBS] Check accumulator chaining by looking for D and C register colocation across consecutive MMAs.
 * [OBS] Check block scaling by looking for `.SF` and post-C scale operands.
 * [OBS] Check sparse MMA by looking for `.SP`, metadata register operand, and selector immediate.
-* [GAP] Grep for `STSM` / `stmatrix` remains provisional because matrix-store SASS has not been studied yet.
+* [OBS] For FP4/FP6 layout audits, distinguish LDSM-fed fragments from direct-register fragments before making lane-layout claims.
+* [RES] Grep for `STSM` is now a valid first-pass matrix-store locator for tested m8n8 b16 SM120 SASS.
 
 ## Cross chapter summary
 
@@ -1935,7 +2127,7 @@ STG epilogue                          [OBS] chapters 13, 14, 16, 19
 | FP64 | DADD (first observed in kernel 08f), DMUL (observed in kernel 11g) |
 | VOTE | VOTE.ANY, VOTE.ALL |
 | REDUX | REDUX, REDUX.OR, REDUX.XOR, REDUX.SUM, REDUX.MIN, REDUX.MAX |
-| TC | HMMA, QMMA, OMMA, QMMA.SP, QMMA.SF.SP, OMMA.SF.SP, LDSM, LDGSTS, LDGDEPBAR, DEPBAR.LE |
+| TC | HMMA, QMMA, QMMA.SF, OMMA.SF, QMMA.SP, QMMA.SF.SP, OMMA.SF.SP, LDSM, STSM, LDGSTS, LDGDEPBAR, DEPBAR.LE |
 
 ### Architectural invariants
 
@@ -2694,11 +2886,17 @@ During an attempt to audit a production fused FP4 attention kernel on SM120, sev
 
 * [RES] Chapter 20 is complete for control flow, loops, unroll behavior, back-edge detection, and local predication vs branching. It closes the minimal-loop portion of GAP-audit-1, resolves tested loop-detection cases in GAP-audit-2, and partially resolves GAP-audit-4 and GAP-audit-5.
 * [RES] Chapter 21 is complete for first-pass divergence and reconvergence coverage, including BSSY/BSYNC, warp-divergent branches, predicated arithmetic, predicated exits, VOTE, SHFL, local CALL, and guarded HMMA/WARPSYNC.ALL.
-* [GAP] Chapter 22 is still required before Phase 3 for stmatrix / matrix store. It is expected to close the matrix-store gap left by chapters 17 and 18.
-* [GAP] Chapter 23 is strongly recommended before Phase 3 for FP4 / FP6 fragment layout. It is expected to close GAP-14d-1 and the FP6/FP4 packing gaps from chapter 15 if runtime validation becomes available.
-* [GAP] Chapter 24 is strongly recommended before Phase 3 for production mini-GEMM audit using LDGSTS + LDSM + QMMA/OMMA + STG end-to-end. It is expected to reduce GAP-audit-6 and GAP-audit-7 before pattern formalization.
+* [RES] Chapter 22 is complete for first-pass stmatrix / matrix-store SASS coverage and runtime smoke execution. It closes the matrix-store gap left by chapters 17 and 18 for tested m8n8 b16 forms.
+* [GAP] Chapter 22 full STSM lane-to-shared layout decode remains open.
+* [RES] Chapter 23 is complete for first-pass FP4 / FP6 fragment-layout SASS coverage and runtime smoke execution, including dense QMMA, LDSM-fed QMMA, direct-register QMMA, scale-vector OMMA, and sparse metadata separation.
+* [GAP] Chapter 23 full runtime value-layout decode remains open; GAP-14d-1 and the FP6/FP4 packing gaps from Chapter 15 are reduced but not fully closed.
+* [RES] Chapter 24 is complete for first-pass production mini-GEMM SASS coverage and runtime smoke execution, including LDGSTS, LDSM, HMMA/QMMA/OMMA, sparse MMA, STSM, STG, REDG, scale-load, metadata-load, and cold-path probes. It reduces GAP-audit-6 by documenting an end-to-end dump segmentation workflow.
+* [GAP] Chapter 24 does not fully close GAP-audit-7 because audit-confidence scoring still needs a written framework beyond the structural probe set.
+* [RES] Chapter 25 is complete for first-pass STSM epilogue/storeback SASS coverage and runtime smoke execution, including STSM layout variants, STS fallback, MMA-to-STSM paths, F16/BF16 narrowing, barrier/no-barrier contrast, split accumulator storeback, noncontiguous global stores, and register-pressure behavior.
+* [GAP] Chapter 25 full lane-to-value STSM semantic decode remains open over the captured runtime words.
 
 ### Decision: Phase 3 gated
 
-* [RES] Phase 3 must not start until remaining required Chapter 22 is complete.
-* [INF] Chapters 23 and 24 are strongly recommended before Phase 3 because fragment layout and an end-to-end production-like audit reduce the risk of formalizing incomplete patterns.
+* [RES] Required Phase 3 gates from Chapters 20, 21, and 22 are complete.
+* [RES] The strongly recommended Chapter 23, 24, and 25 structural chapters are complete for first-pass SASS coverage and runtime smoke execution.
+* [INF] An audit confidence framework remains strongly recommended before Phase 3 pattern formalization because the structural chapters do not define how to score confidence for production-kernel conclusions.

--- a/knowledge/ISA_COVERAGE.md
+++ b/knowledge/ISA_COVERAGE.md
@@ -1,0 +1,207 @@
+# ISA Coverage Tracker
+
+This tracker measures coverage against a historical SASS instruction-family seed list. It is not proof that every listed family exists on SM120.
+
+Claims use the project tags:
+
+* [OBS] Observed in local SASS dumps, logs, or project findings.
+* [INF] Inferred from local project structure or controlled comparisons.
+* [HYP] Plausible but not validated locally.
+* [GAP] Not yet observed, not yet cataloged, or not yet tested.
+
+## Purpose
+
+SASS King aims to document the full ISA over time, but not every family needs the same depth immediately. [INF]
+
+Coverage has three levels:
+
+| Level | Meaning | Expected output |
+|---|---|---|
+| Inventory | The family is listed in the coverage tracker, even if not observed locally. | Row in this file. |
+| Glossary | The family has a short explanation, source trigger, and importance. | Row in `SASS_INSTRUCTIONS_SM120.md`. |
+| Encoding | The family has canonical forms, operands, modifiers, and matching notes. | Page under `encoding/`. |
+
+## Current Counts
+
+| Metric | Count | Status |
+|---|---:|---|
+| Historical seed families including removed and reverse-engineered extras | 293 | [INF] Counted from the seed list in this file. |
+| Seed families remaining after applying the listed removals | 256 | [INF] Removal arithmetic only; this is not proof of SM120 support. |
+| Families extracted from local `.sass` dumps by mnemonic scan | 62 | [INF] Raw extraction includes real observations but still needs manual review. |
+| Families with glossary rows in `SASS_INSTRUCTIONS_SM120.md` | 31 | [INF] Current documented glossary scope. |
+| Families with dedicated encoding pages | 3 | [OBS] `LDSM`, `STSM`, `QMMA`. |
+
+## Status Values
+
+| Status | Meaning |
+|---|---|
+| `documented` | Observed locally and explained in `SASS_INSTRUCTIONS_SM120.md`. |
+| `observed_uncataloged` | Observed locally, but not yet promoted into the glossary inventory. |
+| `watchlist` | Listed in the historical seed, but not yet observed locally. |
+| `removed_or_out_of_scope` | Listed as removed before Blackwell or explicitly out of SM120 scope. |
+| `needs_probe` | Important enough to justify a controlled kernel or production audit search. |
+| `encoding_page` | Has a dedicated page under `knowledge/encoding/`. |
+
+## SM120 / SM120a Documented Families
+
+These families are already represented in `SASS_INSTRUCTIONS_SM120.md`. [OBS]
+
+| Family | Coverage | Detailed page | Notes |
+|---|---|---|---|
+| HMMA | documented |  | Baseline FP16/BF16 MMA family. |
+| QMMA | documented | `encoding/QMMA.md` | Dense, scaled, and sparse low-precision MMA family. |
+| OMMA | documented |  | FP4 peak MMA family observed through `.SF` forms. |
+| LDSM | documented | `encoding/LDSM.md` | Matrix-fragment shared-memory load family. |
+| STSM | documented | `encoding/STSM.md` | Matrix-fragment shared-memory store family. |
+| LDGSTS | documented |  | Async global-to-shared staging path. |
+| LDGDEPBAR | documented |  | Async-copy dependency helper. |
+| DEPBAR | documented |  | Async-copy wait path. |
+| BAR | documented |  | CTA barrier form. |
+| LDS | documented |  | Shared-memory load family. |
+| STS | documented |  | Shared-memory store family. |
+| LDG | documented |  | Global-memory load family. |
+| STG | documented |  | Global-memory store family. |
+| REDG | documented |  | Global reduction writeback observed in split-K style stub. |
+| BRA | documented |  | Branch family. |
+| EXIT | documented |  | Kernel exit form. |
+| BSSY | documented |  | Reconvergence marker. |
+| BSYNC | documented |  | Reconvergence marker. |
+| WARPSYNC | documented |  | Warp synchronization form. |
+| SHFL | documented |  | Warp shuffle family. |
+| VOTE | documented |  | Warp vote family. |
+| REDUX | documented |  | Warp reduction family. |
+| S2UR | documented |  | Special-register to uniform-register path. |
+| R2UR | documented |  | Register to uniform-register path. |
+| UMOV | documented |  | Uniform move family. |
+| ULEA | documented |  | Uniform address arithmetic. |
+| LDCU | documented |  | Uniform constant load family. |
+
+## Observed But Not Yet Cataloged
+
+These mnemonics appear in local dumps or `knowledge/FINDINGS.md`, but they still need glossary rows or a decision to keep them as low-priority background families. [OBS]
+
+| Family | Evidence | Priority | Next action |
+|---|---|---|---|
+| CS2R | Chapters 11 and tensor-core latency probes | medium | Add special-register read glossary entry. |
+| CS2UR | Chapters 13-17, 19 and findings | high | Add uniform special-register read glossary entry. |
+| BPT | Local dump extraction | low | Verify context before cataloging. |
+| CALL | Local dump extraction | low | Verify whether only cold/assert paths use it. |
+| F2F | Local dump extraction | medium | Add conversion family when numeric conversion chapter is updated. |
+| FADD | Local dump extraction | medium | Add scalar FP arithmetic row. |
+| FFMA | Local dump extraction | medium | Add scalar FP fused multiply-add row. |
+| FSEL | Local dump extraction | medium | Add scalar select row. |
+| FSETP | Local dump extraction | medium | Add FP predicate compare row. |
+| HFMA2 | Local dump extraction | medium | Add packed half arithmetic row. |
+| I2FP | Local dump extraction | medium | Add integer-to-float conversion row. |
+| IADD | Local dump extraction | medium | Add integer arithmetic row. |
+| IMAD | Local dump extraction | medium | Add integer multiply-add row. |
+| ISETP | Local dump extraction | medium | Add integer predicate compare row. |
+| LDC | Local dump extraction | medium | Add constant load row and distinguish from `LDCU`. |
+| LDL | Local dump extraction | medium | Add local-memory load row when spill chapter is refreshed. |
+| LEA | Local dump extraction | medium | Add per-lane address arithmetic row. |
+| LOP3 | Local dump extraction | medium | Add logical ternary operation row. |
+| MOV | Local dump extraction | medium | Add register move row. |
+| NOP | Local dump extraction | low | Add scheduling/padding row if useful for control-code work. |
+| PLOP3 | Local dump extraction | low | Verify predicate logic context before cataloging. |
+| PRMT | Local dump extraction | medium | Add byte/word permutation row. |
+| R2P | Local dump extraction | low | Verify predicate-register movement context. |
+| RET | Local dump extraction | low | Verify function-return context. |
+| S2R | Local dump extraction | high | Add special-register read row. |
+| SEL | Local dump extraction | medium | Add scalar select row. |
+| SHF | Local dump extraction | medium | Add funnel-shift row. |
+| STL | Local dump extraction | medium | Add local-memory store row when spill chapter is refreshed. |
+| UFSEL | Local dump extraction | medium | Add uniform FP select row. |
+| UI2FP | Local dump extraction | medium | Add uniform integer-to-float conversion row. |
+| UIADD3 | Local dump extraction | medium | Add uniform integer add row. |
+| UISETP | Local dump extraction | medium | Add uniform predicate compare row. |
+| ULOP3 | Local dump extraction | medium | Add uniform logical ternary row. |
+| UPLOP3 | Local dump extraction | low | Verify uniform predicate logic context. |
+| USHF | Local dump extraction | medium | Add uniform shift row. |
+| VOTEU | Local dump extraction | low | Verify relationship to `VOTE`. |
+
+## Blackwell Watchlist
+
+These families are listed as Blackwell additions in the seed list. Status is local-project status, not architectural truth. [GAP]
+
+| Family | Local status | Priority | Notes |
+|---|---|---|---|
+| ACQSHMINIT | watchlist | low | Not observed locally. |
+| CREDUX | watchlist | high | Mentioned as possible cluster-scope family in findings, not tested locally. |
+| CS2UR | observed_uncataloged | high | Observed locally, needs glossary row. |
+| FADD2 | watchlist | medium | Not observed locally. |
+| FFMA2 | watchlist | medium | Not observed locally. |
+| FHADD | watchlist | medium | Not observed locally. |
+| FHFMA | watchlist | medium | Not observed locally. |
+| FMNMX3 | watchlist | medium | Not observed locally. |
+| FMUL2 | watchlist | medium | Not observed locally. |
+| LDCU | documented | medium | Observed and cataloged. |
+| LDT | watchlist | medium | Not observed locally. |
+| LDTM | watchlist | medium | Not observed locally. |
+| OMMA | documented | high | Observed and cataloged. |
+| QMMA | encoding_page | high | Observed, cataloged, and has encoding page. |
+| STT | watchlist | medium | Not observed locally. |
+| STTM | watchlist | medium | Not observed locally. |
+| UF2F | watchlist | medium | Not observed locally. |
+| UF2I | watchlist | medium | Not observed locally. |
+| UF2IP | watchlist | medium | Not observed locally. |
+| UFADD | watchlist | medium | Not observed locally. |
+| UFFMA | watchlist | medium | Not observed locally. |
+| UFMNMX | watchlist | medium | Not observed locally. |
+| UFMUL | watchlist | medium | Not observed locally. |
+| UFRND | watchlist | medium | Not observed locally. |
+| UFSEL | observed_uncataloged | medium | Observed locally, needs glossary row. |
+| UFSET | watchlist | medium | Not observed locally. |
+| UFSETP | watchlist | medium | Not observed locally. |
+| UGETNEXTWORKID | watchlist | low | Not observed locally. |
+| UI2F | watchlist | medium | Not observed locally. |
+| UI2FP | observed_uncataloged | medium | Observed locally, needs glossary row. |
+| UI2I | watchlist | medium | Not observed locally. |
+| UI2IP | watchlist | medium | Not observed locally. |
+| UIABS | watchlist | medium | Not observed locally. |
+| UIMNMX | watchlist | medium | Not observed locally. |
+| UMEMSETS | watchlist | low | Not observed locally. |
+| UREDGR | watchlist | high | Reduction/writeback watchlist item. |
+| USTGR | watchlist | high | Store/writeback watchlist item. |
+| UTCATOMSWS | watchlist | high | Atomic-related watchlist item. |
+| UTCBAR | watchlist | medium | Not observed locally. |
+| UTCCP | watchlist | medium | Not observed locally. |
+| UTCHMMA | watchlist | medium | Not observed locally. |
+| UTCIMMA | watchlist | medium | Not observed locally. |
+| UTCOMMA | watchlist | high | Related to OMMA path, not observed locally. |
+| UTCQMMA | watchlist | high | Related to QMMA path, not observed locally. |
+| UTCSHIFT | watchlist | medium | Not observed locally. |
+| UVIADD | watchlist | medium | Not observed locally. |
+| UVIMNMX | watchlist | medium | Not observed locally. |
+| UVIRTCOUNT | watchlist | low | Not observed locally. |
+
+## Removed Before Blackwell According To Seed
+
+These are tracked so they are not accidentally treated as missing SM120 work. [INF]
+
+| Generation | Removed families |
+|---|---|
+| Volta | `BFE`, `BFI`, `BRK`, `CAL`, `CONT`, `CSET`, `CSETP`, `DMNMX`, `DSET`, `FCMP`, `ICMP`, `IMADSP`, `ISET`, `JCAL`, `PBK`, `PCNT`, `PEXIT`, `PRET`, `PSET`, `RRO`, `SSY`, `SYNC`, `TEXS`, `TLD4S`, `TLDS`, `XMAD` |
+| Ampere / Ada | `R2B`, `RTT` |
+| Hopper | `RED` |
+| Blackwell | `BGMMA`, `BMMA`, `HGMMA`, `IGMMA`, `QGMMA`, `ULDC`, `WARPGROUP`, `WARPGROUPSET` |
+
+## Historical Seed Lists
+
+The following seed lists are copied into the tracker as a watchlist source. They are not local observations. [GAP]
+
+| Architecture band | Added or baseline families |
+|---|---|
+| Maxwell / Pascal baseline | `ATOM`, `ATOMS`, `B2R`, `BAR`, `BFE`, `BFI`, `BPT`, `BRA`, `BRK`, `BRX`, `CAL`, `CCTL`, `CCTLL`, `CCTLT`, `CONT`, `CS2R`, `CSET`, `CSETP`, `DADD`, `DFMA`, `DMNMX`, `DMUL`, `DSET`, `DSETP`, `EXIT`, `F2F`, `F2I`, `FADD`, `FCHK`, `FCMP`, `FFMA`, `FLO`, `FMNMX`, `FMUL`, `FSET`, `FSETP`, `FSWZADD`, `HADD2`, `HFMA2`, `HMUL2`, `HSET2`, `HSETP2`, `I2F`, `I2I`, `IADD`, `IADD3`, `ICMP`, `IMAD`, `IMADSP`, `IMNMX`, `IMUL`, `ISCADD`, `ISET`, `ISETP`, `JCAL`, `JMP`, `JMX`, `LD`, `LDC`, `LDG`, `LDL`, `LDS`, `LEA`, `LOP`, `LOP3`, `MEMBAR`, `MOV`, `MUFU`, `NOP`, `P2R`, `PBK`, `PCNT`, `PEXIT`, `POPC`, `PRET`, `PRMT`, `PSET`, `PSETP`, `R2B`, `R2P`, `RED`, `RET`, `RRO`, `S2R`, `SEL`, `SHF`, `SHFL`, `SHL`, `SHR`, `SSY`, `ST`, `STG`, `STL`, `STS`, `SUATOM`, `SULD`, `SURED`, `SUST`, `SYNC`, `TEX`, `TEXS`, `TLD`, `TLD4`, `TLD4S`, `TLDS`, `TXQ`, `VOTE`, `XMAD` |
+| Volta additions | `ATOMG`, `BMOV`, `BMSK`, `BREAK`, `BREV`, `BSSY`, `BSYNC`, `CALL`, `DEPBAR`, `ERRBAR`, `FADD32I`, `FFMA32I`, `FMUL32I`, `FRND`, `FSEL`, `GETLMEMBASE`, `HADD2_32I`, `HFMA2_32I`, `HMMA`, `HMUL2_32I`, `I2IP`, `IABS`, `IADD32I`, `IDP`, `IDP4A`, `IMMA`, `IMUL32I`, `ISCADD32I`, `KILL`, `LEPC`, `LOP32I`, `MATCH`, `MOV32I`, `NANOSLEEP`, `PLOP3`, `PMTRIG`, `QSPC`, `RPCMOV`, `RTT`, `SETCTAID`, `SETLMEMBASE`, `SGXT`, `TMML`, `TXD`, `VABSDIFF`, `VABSDIFF4`, `WARPSYNC`, `YIELD` |
+| Turing additions | `BMMA`, `BRXU`, `JMXU`, `LDSM`, `MOVM`, `R2UR`, `S2UR`, `UBMSK`, `UBREV`, `UCLEA`, `UFLO`, `UIADD3`, `UIADD3.64`, `UIMAD`, `UISETP`, `ULDC`, `ULEA`, `ULOP`, `ULOP3`, `ULOP32I`, `UMOV`, `UP2UR`, `UPLOP3`, `UPOPC`, `UPRMT`, `UPSETP`, `UR2UP`, `USEL`, `USGXT`, `USHF`, `USHL`, `USHR`, `VOTEU` |
+| Ampere / Ada additions | `DMMA`, `F2IP`, `HMNMX2`, `I2FP`, `LDGDEPBAR`, `LDGSTS`, `REDUX`, `UF2FP` |
+| Hopper additions | `ACQBULK`, `BGMMA`, `CGAERRBAR`, `ELECT`, `ENDCOLLECTIVE`, `FENCE`, `HGMMA`, `IGMMA`, `LDGMC`, `PREEXIT`, `QGMMA`, `REDAS`, `REDG`, `STAS`, `STSM`, `SYNCS`, `UBLKCP`, `UBLKPF`, `UBLKRED`, `UCGABAR_ARV`, `UCGABAR_WAIT`, `ULEPC`, `USETMAXREG`, `UTMACCTL`, `UTMACMDFLUSH`, `UTMALDG`, `UTMAPF`, `UTMAREDG`, `UTMASTG`, `VHMNMX`, `VIADD`, `VIADDMNMX`, `VIMNMX`, `VIMNMX3`, `WARPGROUP`, `WARPGROUPSET` |
+| Blackwell additions | `ACQSHMINIT`, `CREDUX`, `CS2UR`, `FADD2`, `FFMA2`, `FHADD`, `FHFMA`, `FMNMX3`, `FMUL2`, `LDCU`, `LDT`, `LDTM`, `OMMA`, `QMMA`, `STT`, `STTM`, `UF2F`, `UF2I`, `UF2IP`, `UFADD`, `UFFMA`, `UFMNMX`, `UFMUL`, `UFRND`, `UFSEL`, `UFSET`, `UFSETP`, `UGETNEXTWORKID`, `UI2F`, `UI2FP`, `UI2I`, `UI2IP`, `UIABS`, `UIMNMX`, `UMEMSETS`, `UREDGR`, `USTGR`, `UTCATOMSWS`, `UTCBAR`, `UTCCP`, `UTCHMMA`, `UTCIMMA`, `UTCOMMA`, `UTCQMMA`, `UTCSHIFT`, `UVIADD`, `UVIMNMX`, `UVIRTCOUNT` |
+| Reverse-engineered extras | `AL2P`, `ALD`, `ARRIVES`, `CSMTEST`, `F2FP`, `FOOTPRINT`, `IPA`, `ISBERD`, `LDTRAM`, `OUT`, `PIXLD`, `SUQUERY`, `USETSHMSZ` |
+
+## Coverage Roadmap
+
+1. Promote high-priority observed but uncataloged families into `SASS_INSTRUCTIONS_SM120.md`: `CS2UR`, `S2R`, `CS2R`, scalar arithmetic, local-memory spill loads/stores. [GAP]
+2. Add a reduction/writeback page once enough `REDG`, `UREDGR`, `USTGR`, or `UTCATOMSWS` evidence exists. [GAP]
+3. Add controlled probes only when a watchlist family is needed for production audit interpretation or fills a known roadmap gap. [INF]
+4. Keep `SASS_INSTRUCTIONS_SM120.md` as the glossary for observed families, and keep this file as the completeness tracker. [INF]

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -1,0 +1,15 @@
+# Knowledge Base
+
+This directory contains the project-wide outputs produced from the chapter probes.
+
+| File | Purpose |
+|---|---|
+| `FINDINGS.md` | Running source of truth for observations, hypotheses, resolutions, gaps, cross-chapter invariants, and canonical patterns. |
+| `ISA_COVERAGE.md` | Completeness tracker for the long-term ISA documentation effort. |
+| `SASS_INSTRUCTIONS_SM120.md` | Evidence-backed SM120 / SM120a instruction inventory. |
+| `encoding/schema.md` | Shared format for instruction-family encoding pages. |
+| `encoding/STSM.md` | Pilot encoding page for matrix-store instructions. |
+| `encoding/LDSM.md` | Pilot encoding page for matrix-load instructions. |
+| `encoding/QMMA.md` | Pilot encoding page for Blackwell dense/sparse FP8/FP6/FP4 MMA instructions. |
+
+Chapter-local files stay with their kernels. For example, `tensor_cores/25_stsm_epilogue/conclusion25.md` documents the local experiment, while `knowledge/FINDINGS.md` records the project-wide result.

--- a/knowledge/SASS_INSTRUCTIONS_SM120.md
+++ b/knowledge/SASS_INSTRUCTIONS_SM120.md
@@ -1,0 +1,98 @@
+# SASS Instructions on SM120 / SM120a
+
+This inventory tracks instruction families observed in this repository. It is not a complete ISA reference. Full coverage status lives in `ISA_COVERAGE.md`.
+
+Claims use the project tags:
+
+* [OBS] Directly observed in local SASS dumps or ptxas logs.
+* [INF] Inferred from controlled comparisons.
+* [GAP] Not yet validated or only partially decoded.
+
+## Tensor-core and matrix instructions
+
+| Family | Mnemonics observed | Meaning | Why it matters | Target | First evidence | Source trigger | Status |
+|---|---|---|---|---|---|---|---|
+| HMMA | `HMMA.16816.F32`, `HMMA.16816.F16` | Warp-level FP16/BF16 matrix multiply-accumulate. | Baseline tensor-core family used to anchor fragment, accumulator, and latency reasoning before Blackwell low-precision forms. | `sm_120`, `sm_120a` | `tensor_cores/13_hmma_fp16/` | `mma.sync.aligned.m16n8k16` | [OBS] Warp-level FP16/BF16 MMA family. |
+| QMMA | `QMMA.16832.*` | Dense Blackwell FP8/FP6/FP4 matrix multiply-accumulate. | Core SM120a low-precision tensor-core compute family for production GEMM and attention audits. | `sm_120a` | `tensor_cores/14_qmma_fp8/` | `mma.sync.aligned.kind::f8f6f4.m16n8k32` | [OBS] Dense FP8/FP6/FP4 MMA family. |
+| QMMA.SF | `QMMA.SF.16832.*` | Dense QMMA with explicit scale-factor operands. | Separates block-scaled numeric behavior from ordinary dense MMA operand flow. | `sm_120a` | `tensor_cores/16_fp4_peak/` | `kind::mxf8f6f4.block_scale` | [OBS] Block-scaled QMMA form. |
+| QMMA.SP | `QMMA.SP.16864.*` | Sparse QMMA with metadata operands and no scale-factor marker. | Exposes the SASS path for structured sparsity and its extra audit channel. | `sm_120a` | `tensor_cores/19_sparse_mma/` | `mma.sp::ordered_metadata...kind::f8f6f4` | [OBS] Sparse non-scaled QMMA form. |
+| QMMA.SF.SP | `QMMA.SF.SP.16864.*` | Sparse block-scaled QMMA. | Combines sparse metadata tracking with scale-factor tracking, so audits must follow both operand classes. | `sm_120a` | `tensor_cores/19_sparse_mma/` | `mma.sp::ordered_metadata...kind::mxf8f6f4.block_scale` | [OBS] Sparse block-scaled QMMA form. |
+| OMMA.SF | `OMMA.SF.16864.*` | Block-scaled FP4 peak MMA family. | Marks the highest-compression FP4 compute path observed in the project. | `sm_120a` | `tensor_cores/16_fp4_peak/` | `kind::mxf4nvf4.block_scale` | [OBS] Block-scaled FP4 peak MMA family. |
+| OMMA.SF.SP | `OMMA.SF.SP.168128.*` | Sparse block-scaled FP4 peak MMA family. | Shows the sparse FP4 peak path and increases the number of metadata/scale operands to audit. | `sm_120a` | `tensor_cores/19_sparse_mma/` | `mma.sp::ordered_metadata...kind::mxf4nvf4.block_scale` | [OBS] Sparse block-scaled FP4 MMA form. |
+| LDSM | `LDSM.16.M88`, `LDSM.16.M88.2`, `LDSM.16.M88.4`, `LDSM.16.MT88.4` | Loads matrix fragments from shared memory into registers. | It is the bridge between shared-memory tiling and MMA fragment operands. | `sm_120`, `sm_120a` | `tensor_cores/17_ldmatrix/` | `ldmatrix.sync.aligned` | [OBS] Shared-memory matrix-fragment load family. |
+| STSM | `STSM.16.M88`, `STSM.16.M88.2`, `STSM.16.M88.4`, `STSM.16.MT88`, `STSM.16.MT88.2`, `STSM.16.MT88.4` | Stores matrix fragments from registers into shared memory. | It explains epilogue layout, shared-memory storeback, and cross-thread readback patterns. | `sm_120`, `sm_120a` | `tensor_cores/22_stmatrix/` | `stmatrix.sync.aligned.m8n8.shared.b16` | [OBS] Shared-memory matrix-fragment store family. |
+| STSM b8 | `STSM.8.MT168`, `STSM.8.MT168.2`, `STSM.8.MT168.4` | Stores 8-bit matrix fragments through the STSM family. | It is target-qualified evidence that some matrix-store forms require `sm_120a`, not plain `sm_120`. | `sm_120a` | `tensor_cores/25_stsm_epilogue/25q_sm120a_b8_stsm.sass` | `stmatrix.sync.aligned.m16n8.*.shared.b8` | [OBS] Plain `sm_120` rejects this form; `sm_120a` accepts it. |
+
+## Memory and synchronization instructions
+
+| Family | Mnemonics observed | Meaning | Why it matters | Target | First evidence | Source trigger | Status |
+|---|---|---|---|---|---|---|---|
+| LDGSTS | `LDGSTS.E.LTC128B.128` | Asynchronous global-to-shared copy. | It is the SASS realization of pipelined tile staging before LDSM and MMA. | `sm_120`, `sm_120a` | `tensor_cores/18_pipelined_tile/` | `cp.async.ca.shared.global.L2::128B` | [OBS] Async global-to-shared copy realization. |
+| LDGDEPBAR | `LDGDEPBAR` | Dependency helper for async-copy groups. | It marks compiler-managed bookkeeping around staged global-to-shared transfers. | `sm_120`, `sm_120a` | `tensor_cores/18_pipelined_tile/` | `cp.async.commit_group` / wait path | [OBS] Async-copy dependency barrier helper. |
+| DEPBAR | `DEPBAR.LE SB0, N` | Waits on scoreboard-backed async-copy progress. | It defines when a staged tile is safe to consume from shared memory. | `sm_120`, `sm_120a` | `tensor_cores/18_pipelined_tile/` | `cp.async.wait_group` | [OBS] Waits on async-copy scoreboard. |
+| BAR | `BAR.SYNC.DEFER_BLOCKING` | CTA-wide synchronization barrier. | It separates producer and consumer phases for shared-memory data visible across threads. | `sm_120`, `sm_120a` | `06_shared_memory_scalar/` | `__syncthreads()` | [OBS] Block barrier form used before shared readback. |
+| LDS | `LDS`, `LDS.128` | Scalar or vector shared-memory load. | It is the ordinary shared-memory read path, distinct from matrix-fragment LDSM. | `sm_120`, `sm_120a` | `06_shared_memory_scalar/` | Shared-memory loads | [OBS] Shared-memory load family. |
+| STS | `STS`, `STS.128` | Scalar or vector shared-memory store. | It is the ordinary shared-memory write path and the fallback contrast for STSM. | `sm_120`, `sm_120a` | `06_shared_memory_scalar/` | Shared-memory stores | [OBS] Scalar/vector shared-store family, distinct from STSM. |
+| LDG | `LDG`, `LDG.E`, `LDG.E.64`, `LDG.E.128`, `LDG.E.CONSTANT`, `LDG.E.ENL2.256` | Global-memory load. | It identifies global input traffic, cache qualifiers, and vectorized access width in audits. | `sm_120`, `sm_120a` | `08_vectorized_load/` | Global loads | [OBS] Global-load family. |
+| STG | `STG`, `STG.E`, `STG.E.64`, `STG.E.128`, `STG.E.ENL2.256` | Global-memory store. | It identifies final output traffic and epilogue writeback width. | `sm_120`, `sm_120a` | `01_vector_add/` | Global stores | [OBS] Global-store family. |
+| REDG | `REDG.E.ADD.F32...` | Global-memory reduction or atomic accumulation form. | It marks split-K or multi-CTA accumulation paths that are not plain stores. | `sm_120a` | `tensor_cores/24_production_mini_gemm/24z_split_k_or_multi_cta_reduction_stub.sass` | `atomicAdd` reduction stub | [OBS] Global reduction form used for split-K style accumulation. |
+
+## Control-flow and warp instructions
+
+| Family | Mnemonics observed | Meaning | Why it matters | Target | First evidence | Source trigger | Status |
+|---|---|---|---|---|---|---|---|
+| BRA | `BRA`, `BRA.U` | Branch instruction. | It is the primary marker for explicit loops, back edges, and non-predicated control flow. | `sm_120` | `04_simple_loop/`, `20_control_flow/` | Branches and loops | [OBS] Branch family. |
+| EXIT | `EXIT`, predicated `EXIT` | Kernel exit instruction. | It marks return paths, bounds-check exits, and final control-flow convergence. | `sm_120` | `01_vector_add/` | Bounds checks and returns | [OBS] Kernel exit form. |
+| BSSY / BSYNC | `BSSY`, `BSYNC`, `BSSY.RECONVERGENT`, `BSYNC.RECONVERGENT` | Divergence and reconvergence markers. | They expose compiler-managed reconvergence regions around divergent branches and cold paths. | `sm_120`, `sm_120a` | `21_divergence_reconvergence/` | Divergence/reconvergence and cold paths | [OBS] Reconvergence markers. |
+| WARPSYNC | `WARPSYNC.ALL` | Warp-level synchronization. | It distinguishes warp-scoped ordering from CTA-scoped barriers. | `sm_120`, `sm_120a` | `21_divergence_reconvergence/` | Guarded warp-level synchronization | [OBS] Warp synchronization form. |
+| SHFL | `SHFL.BFLY`, `SHFL.IDX`, `SHFL.UP`, `SHFL.DOWN` | Cross-lane register exchange inside a warp. | It identifies warp-level data movement without shared memory. | `sm_120` | `09_warp_shuffling/` | Warp shuffles | [OBS] Warp shuffle family. |
+| VOTE | `VOTE.ANY`, `VOTE.ALL` | Warp-level predicate vote. | It shows collective boolean decisions across lanes. | `sm_120` | `09_warp_shuffling/` | Warp votes | [OBS] Warp vote family. |
+| REDUX | `REDUX`, `REDUX.SUM`, `REDUX.MIN`, `REDUX.MAX`, `REDUX.OR`, `REDUX.XOR` | Warp-level reduction. | It is the compact SASS signature for warp reductions that do not expand into shuffle trees. | `sm_120` | `10_reduce/` | Warp reductions | [OBS] Warp reduction family. |
+
+## Uniform-register instructions
+
+| Family | Mnemonics observed | Meaning | Why it matters | Target | First evidence | Source trigger | Status |
+|---|---|---|---|---|---|---|---|
+| S2UR | `S2UR` | Moves special-register values into uniform registers. | It shows when warp-uniform state is represented in the uniform register file. | `sm_120`, `sm_120a` | `07_umov/` | Uniform special-register movement | [OBS] Moves special-register values into uniform registers. |
+| R2UR | `R2UR` | Moves a general register value into a uniform register. | It marks compiler-selected promotion from per-thread register flow into uniform flow. | `sm_120`, `sm_120a` | `12_register_spill/`, `21_divergence_reconvergence/` | Per-thread to uniform path selected by ptxas | [OBS] Register-to-uniform-register move. |
+| UMOV | `UMOV`, `UMOV.64` | Uniform-register move or immediate materialization. | It is the basic data movement instruction inside uniform register flow. | `sm_120`, `sm_120a` | `07_umov/` | Uniform immediate moves | [OBS] Uniform MOV family. |
+| ULEA | `ULEA` | Uniform address arithmetic. | It identifies address computation done once per warp-uniform path rather than per lane. | `sm_120`, `sm_120a` | `06_shared_memory_scalar/` | Uniform address arithmetic | [OBS] Uniform LEA family. |
+| LDCU | `LDCU`, `LDCU.64` | Uniform constant-memory load. | It marks kernel parameter and constant loads that feed uniform computation. | `sm_120`, `sm_120a` | `01_vector_add/` | Uniform constant loads | [OBS] Uniform constant-load family. |
+
+## Not observed / out of SM120 scope
+
+| Family | Meaning | Why it matters | Status |
+|---|---|---|---|
+| WGMMA / warpgroup MMA | Warpgroup-level matrix multiply family known from other NVIDIA architecture contexts. | Its absence prevents importing SM90-style warpgroup assumptions into SM120 findings. | [OBS] Not observed in the SM120/SM120a dumps through Kernel 25; warpgroup MMA is out of scope for consumer SM120. |
+| TCGEN / TMEM | Tensor memory and tcgen-style datacenter Blackwell path. | Its absence keeps SM120 consumer analysis separate from SM100a datacenter mechanisms. | [OBS] Not observed in the SM120/SM120a dumps through Kernel 25; Blackwell datacenter SM100a feature, not consumer SM120 scope. |
+| Full control-code bit decoder | Complete bit-level decoder for wait, stall, yield, barrier, and reuse fields. | It would make scheduling analysis mechanical instead of partially inferred. | [GAP] Deferred. Partial control-code observations live in `knowledge/FINDINGS.md`. |
+
+## Glossary
+
+### Tensor-core and matrix path
+
+`HMMA` is the established FP16/BF16 warp-level MMA family used as the baseline for tensor-core analysis. It matters because its fragment and accumulator structure gives a reference point for newer low-precision families. [OBS]
+
+`QMMA` is the Blackwell low-precision dense MMA family observed for FP8/FP6/FP4 forms. It matters because most SM120a tensor-core audits depend on recognizing its dtype, accumulator, sparse, and scale-factor variants. [OBS]
+
+`OMMA` is the observed FP4 peak MMA family in block-scaled paths. It matters because it marks a different low-precision compute family from dense QMMA and carries separate operand-shape expectations. [OBS]
+
+`LDSM` loads matrix fragments from shared memory into registers. It matters because MMA operands are often prepared by LDSM, so its ordering and width suffixes explain the fragment supply path. [OBS]
+
+`STSM` stores matrix fragments from registers into shared memory. It matters because it defines storeback and epilogue patterns that cannot be explained by scalar `STS` alone. [OBS]
+
+### Memory and synchronization path
+
+`LDGSTS`, `LDGDEPBAR`, and `DEPBAR` form the observed async-copy staging path. They matter because production tensor-core kernels overlap global-memory movement with shared-memory tile consumption. [OBS]
+
+`LDS` and `STS` are ordinary shared-memory load/store families. They matter because they are the contrast set for matrix-specific `LDSM` and `STSM` instructions. [OBS]
+
+`LDG`, `STG`, and `REDG` identify global-memory input, output, and reduction traffic. They matter because production audits need to distinguish plain epilogue stores from reduction accumulation. [OBS]
+
+### Control and uniform path
+
+`BRA`, `EXIT`, `BSSY`, and `BSYNC` define explicit branch, exit, and reconvergence structure. They matter because control-flow shape is part of the SASS signature, not only a byproduct of source-level branching. [OBS]
+
+`SHFL`, `VOTE`, and `REDUX` are warp-level collective families. They matter because they expose cross-lane computation without shared-memory traffic. [OBS]
+
+`S2UR`, `R2UR`, `UMOV`, `ULEA`, and `LDCU` define uniform-register flow. They matter because uniform operands and addresses must be tracked separately from per-lane register flow. [OBS]

--- a/knowledge/encoding/LDSM.md
+++ b/knowledge/encoding/LDSM.md
@@ -1,0 +1,50 @@
+# LDSM
+
+## Scope
+
+LDSM is the SASS matrix-load family observed for `ldmatrix.sync.aligned` on SM120 / SM120a.
+
+## Evidence
+
+| Source | Evidence |
+|---|---|
+| `tensor_cores/17_ldmatrix/` | [OBS] Baseline x1/x2/x4 and transpose probes. |
+| `tensor_cores/18_pipelined_tile/` | [OBS] LDSM in pipelined tile context. |
+| `tensor_cores/23_fragment_layout/` | [OBS] LDSM-fed FP4/FP6 QMMA path. |
+| `tensor_cores/24_production_mini_gemm/` | [OBS] Production-like LDSM order and alignment probes. |
+
+## Canonical Forms
+
+| Key | Distilled form | Meaning | Why it matters | Evidence | Notes |
+|---|---|---|---|---|---|
+| `LDSM_R_R` | `LDSM.16.M88 R, [R]` | Loads one b16 matrix fragment group from shared memory. | Baseline matrix-load signature before MMA operand use. | `tensor_cores/17_ldmatrix/17a_ldmatrix_x1.sass` | [OBS] x1 non-transposed b16 load. |
+| `LDSM_R_R_X2` | `LDSM.16.M88.2 R, [R]` | Loads two b16 matrix fragment groups. | Width suffix changes destination register footprint. | `tensor_cores/17_ldmatrix/17b_ldmatrix_x2.sass` | [OBS] x2 non-transposed b16 load. |
+| `LDSM_R_R_X4` | `LDSM.16.M88.4 R, [R]` | Loads four b16 matrix fragment groups. | Common high-width fragment supply form for tensor-core tiles. | `tensor_cores/17_ldmatrix/17c_ldmatrix_x4.sass` | [OBS] x4 non-transposed b16 load. |
+| `LDSM_T_R_R_X4` | `LDSM.16.MT88.4 R, [R]` | Loads four transposed b16 matrix fragment groups. | Distinguishes transpose-driven layout handling from ordinary fragment loads. | `tensor_cores/17_ldmatrix/17d_ldmatrix_x4_trans.sass` | [OBS] x4 transposed b16 load. |
+| `LDSM_OFFSET_R_R_XN` | `LDSM.16.M88[.2|.4] R, [R+imm]` | Loads matrix fragments from an offset shared-memory address. | Captures alignment and layout variants without changing the instruction family. | `tensor_cores/24_production_mini_gemm/24q_shared_memory_alignment_variant.sass` | [OBS] Offset shared-memory load addresses. |
+
+## Operand Model
+
+| Operand | Role | Status |
+|---|---|---|
+| `R` destination | Fragment register base | [OBS] Destination register group depends on width suffix. |
+| `[R]` / `[R+imm]` | Shared-memory source address | [OBS] Address can include immediate offset after ptxas address arithmetic. |
+
+## Modifier / Field Model
+
+| Field | Values observed | Evidence | Status |
+|---|---|---|---|
+| Element size | `.16` | Chapter 17 | [OBS] Tested LDSM forms are b16. |
+| Shape | `M88`, `MT88` | Chapter 17 | [OBS] `T` inside shape marks transposed form in observed mnemonics. |
+| Width | none, `.2`, `.4` | Chapter 17 | [OBS] Width suffix maps x1/x2/x4. |
+
+## Matching Notes
+
+* [OBS] Production-like HMMA/QMMA tiles commonly show `LDSM.16.M88.2` and `LDSM.16.M88.4` before MMA.
+* [INF] The specific A/B fragment role is contextual; do not assign A or B purely from the mnemonic without checking operand flow.
+* [OBS] Offset shared-memory forms preserve the LDSM family and expose alignment/layout effects.
+
+## Open Gaps
+
+* [GAP] Complete lane-to-fragment mapping is not fully decoded for all width/transpose combinations.
+* [GAP] Complete control-code field mapping is not decoded.

--- a/knowledge/encoding/QMMA.md
+++ b/knowledge/encoding/QMMA.md
@@ -1,0 +1,61 @@
+# QMMA
+
+## Scope
+
+QMMA is the Blackwell SASS MMA family observed for dense, scaled, and sparse FP8/FP6/FP4 `mma.sync` / `mma.sp` forms on SM120a.
+
+## Evidence
+
+| Source | Evidence |
+|---|---|
+| `tensor_cores/14_qmma_fp8/` | [OBS] Dense `kind::f8f6f4` dtype variants and latency chains. |
+| `tensor_cores/16_fp4_peak/` | [OBS] `QMMA.SF` block-scaled forms. |
+| `tensor_cores/19_sparse_mma/` | [OBS] `QMMA.SP` and `QMMA.SF.SP` sparse forms. |
+| `tensor_cores/23_fragment_layout/` | [OBS] FP4/FP6 layout and LDSM-fed QMMA probes. |
+| `tensor_cores/24_production_mini_gemm/` | [OBS] Production-like QMMA, sparse metadata, and epilogue context. |
+| `tensor_cores/25_stsm_epilogue/` | [OBS] QMMA-to-STSM epilogue path. |
+
+## Canonical Forms
+
+| Key | Distilled form | Meaning | Why it matters | Evidence | Notes |
+|---|---|---|---|---|---|
+| `QMMA_D_A_B_C` | `QMMA.16832.F32.<A>.<B> D, A, B, C` | Dense low-precision MMA accumulating into F32. | Baseline QMMA matcher for FP8/FP6/FP4 compute paths. | `tensor_cores/14_qmma_fp8/14a_qmma_e4m3_e4m3_f32.sass` | [OBS] Dense FP8/FP6/FP4 accumulator form. |
+| `QMMA_F16_D_A_B_C` | `QMMA.16832.F16.<A>.<B> D, A, B, C` | Dense low-precision MMA accumulating into F16. | Separates accumulator dtype effects from input dtype effects. | `tensor_cores/14_qmma_fp8/14j_qmma_e4m3_e4m3_f16.sass` | [OBS] F16 accumulator variant. |
+| `QMMA_SF_D_A_B_C_SCALES` | `QMMA.SF.16832.F32.<A>.<B>.<scale> D, A, B, C, ...` | Dense block-scaled QMMA with extra scale operands. | Requires scale-factor operand tracking in addition to A/B/C/D flow. | `tensor_cores/23_fragment_layout/23i_scale_factor_interaction.sass` | [OBS] Dense block-scaled QMMA form. |
+| `QMMA_SP_D_A_B_C_META` | `QMMA.SP.16864.F32.<A>.<B> D, A, B, C, meta, selector` | Sparse QMMA with metadata and selector operands. | Marks structured sparsity and changes the operand audit model. | `tensor_cores/24_production_mini_gemm/24r_sparse_qmma_tile.sass` | [OBS] Sparse non-scaled form. |
+| `QMMA_SF_SP_D_A_B_C_META_SCALES` | `QMMA.SF.SP.16864.F32.<A>.<B>.<scale> D, A, B, C, meta, ...` | Sparse block-scaled QMMA. | Combines metadata, selector, and scale-factor channels in one compute instruction. | `tensor_cores/19_sparse_mma/19i_sparse_mxf8f6f4_e3m2_e2m1.sass` | [OBS] Sparse block-scaled form. |
+
+## Operand Model
+
+| Operand | Role | Status |
+|---|---|---|
+| `D` | Destination accumulator register base | [OBS] First SASS operand. |
+| `A` | A fragment register base | [OBS] Second SASS operand. |
+| `B` | B fragment register base | [OBS] Third SASS operand. |
+| `C` | Input accumulator register base | [OBS] Fourth SASS operand; chained MMAs colocate D and C after the first instruction. |
+| `meta` | Sparse metadata register | [OBS] Present on `.SP` forms. |
+| Scale operands | Scale-factor registers / uniform placeholders | [OBS] Present on `.SF` forms. |
+
+## Modifier / Field Model
+
+| Field | Values observed | Evidence | Status |
+|---|---|---|---|
+| Shape | `16832`, `16864` | Chapters 14, 19, 23, 24 | [OBS] Dense non-scaled QMMA uses `16832`; sparse observed forms use `16864`. |
+| Accumulator dtype | `F32`, `F16` | Chapter 14 | [OBS] Accumulator dtype appears after shape. |
+| Input dtype | `E4M3`, `E5M2`, `E3M2`, `E2M3`, `E2M1` | Chapters 14, 15, 23 | [OBS] A/B dtypes are explicit in mnemonic. |
+| Scale marker | `.SF` | Chapters 16, 19, 23 | [OBS] Marks block-scaled form. |
+| Sparse marker | `.SP` | Chapters 19, 24, 25 | [OBS] Marks sparse metadata form. |
+| Scale dtype | `.E8`, `.UE4M3` in related scaled families | Chapters 16, 19, 23 | [OBS] Scale dtype is mnemonic-visible where emitted. |
+
+## Matching Notes
+
+* [RES] `QMMA` low opcode byte observed as `0x7a` across tested dense and sparse forms.
+* [RES] Dtype should be read from the mnemonic, not guessed from opcode low byte alone.
+* [RES] Sparse metadata and scale operands must be tracked as separate audit channels.
+* [OBS] LDSM-fed and direct-register QMMA paths are distinct in surrounding instructions, not in the QMMA mnemonic alone.
+
+## Open Gaps
+
+* [GAP] Full FP4/FP6 lane-to-value decode remains open.
+* [GAP] Exact `.SP` bit placement in opcode/control fields remains deferred.
+* [GAP] Complete control-code field mapping is not decoded.

--- a/knowledge/encoding/STSM.md
+++ b/knowledge/encoding/STSM.md
@@ -1,0 +1,51 @@
+# STSM
+
+## Scope
+
+STSM is the SASS matrix-store family observed for `stmatrix.sync.aligned` on SM120 / SM120a.
+
+## Evidence
+
+| Source | Evidence |
+|---|---|
+| `tensor_cores/22_stmatrix/` | [OBS] First-pass m8n8 b16 STSM forms and STS fallback. |
+| `tensor_cores/25_stsm_epilogue/` | [OBS] Epilogue/storeback probes, b8 target compatibility, conversions, barrier/readback patterns. |
+
+## Canonical Forms
+
+| Key | Distilled form | Meaning | Why it matters | Evidence | Notes |
+|---|---|---|---|---|---|
+| `STSM_R_R` | `STSM.16.M88 [R], R` | Stores one b16 matrix fragment group to shared memory. | Baseline non-transposed STSM signature for epilogue matching. | `tensor_cores/25_stsm_epilogue/25a_stsm_x1_runtime_layout.sass` | [OBS] x1 non-transposed b16 store. |
+| `STSM_R_R_X2` | `STSM.16.M88.2 [R], R` | Stores two b16 matrix fragment groups. | Width suffix changes register consumption and shared-memory footprint. | `tensor_cores/25_stsm_epilogue/25b_stsm_x2_runtime_layout.sass` | [OBS] x2 non-transposed b16 store. |
+| `STSM_R_R_X4` | `STSM.16.M88.4 [R], R` | Stores four b16 matrix fragment groups. | Wider store form is a stronger signal for tiled epilogue storeback. | `tensor_cores/25_stsm_epilogue/25c_stsm_x4_runtime_layout.sass` | [OBS] x4 non-transposed b16 store. |
+| `STSM_T_R_R` | `STSM.16.MT88 [R], R` | Stores one transposed b16 matrix fragment group. | Distinguishes layout transformation from plain shared-memory storeback. | `tensor_cores/25_stsm_epilogue/25d_stsm_x1_trans_runtime_layout.sass` | [OBS] x1 transposed b16 store. |
+| `STSM_T_R_R_X2` | `STSM.16.MT88.2 [R], R` | Stores two transposed b16 matrix fragment groups. | Combines transpose and width suffix in the matcher key. | `tensor_cores/25_stsm_epilogue/25e_stsm_x2_trans_runtime_layout.sass` | [OBS] x2 transposed b16 store. |
+| `STSM_T_R_R_X4` | `STSM.16.MT88.4 [R], R` | Stores four transposed b16 matrix fragment groups. | Common high-width transposed form for matrix storeback classification. | `tensor_cores/25_stsm_epilogue/25f_stsm_x4_trans_runtime_layout.sass` | [OBS] x4 transposed b16 store. |
+| `STSM_B8_T_R_R_XN` | `STSM.8.MT168[.2|.4] [R], R` | Stores transposed 8-bit matrix fragments. | Captures the `sm_120a`-qualified b8 matrix-store path. | `tensor_cores/25_stsm_epilogue/25q_sm120a_b8_stsm.sass` | [OBS] sm_120a b8 forms; plain sm_120 rejects the PTX. |
+
+## Operand Model
+
+| Operand | Role | Status |
+|---|---|---|
+| `[R]` | Shared-memory destination address | [OBS] Direct shared address register. |
+| `R` | Source register base | [OBS] Register group consumed by STSM. |
+
+## Modifier / Field Model
+
+| Field | Values observed | Evidence | Status |
+|---|---|---|---|
+| Element size | `.16`, `.8` | Chapters 22 and 25 | [OBS] `.16` for m8n8 b16; `.8` for sm_120a m16n8 b8. |
+| Shape | `M88`, `MT88`, `MT168` | Chapters 22 and 25 | [OBS] `T` inside shape marks transposed form in observed mnemonics. |
+| Width | none, `.2`, `.4` | Chapters 22 and 25 | [OBS] Width suffix maps x1/x2/x4. |
+| Target | `sm_120`, `sm_120a` | `25q_negative_invalid_b8_stsm.log`, `25q_sm120a_b8_stsm.sass` | [RES] b8 is target-qualified. |
+
+## Matching Notes
+
+* [RES] First-pass epilogue matcher should recognize `STSM -> BAR -> LDS -> STG` as the cross-thread storeback pattern.
+* [RES] `STS.128` is a fallback/shared-store family, not STSM.
+* [OBS] No-barrier same-thread contrast exists as adjacent `STSM` and `LDS` in 25n, but it does not prove cross-thread visibility without a barrier.
+
+## Open Gaps
+
+* [GAP] Full lane-to-value semantic layout remains undecoded from runtime words.
+* [GAP] STSM latency and complete control-code field mapping are not decoded.

--- a/knowledge/encoding/schema.md
+++ b/knowledge/encoding/schema.md
@@ -1,0 +1,48 @@
+# Encoding Page Schema
+
+Encoding pages are structured notes for instruction-family matching. They are not complete hardware specifications unless explicitly marked as such.
+
+## Required Sections
+
+Each page should use this structure:
+
+1. `# <Family>`
+2. `## Scope`
+3. `## Evidence`
+4. `## Canonical Forms`
+5. `## Operand Model`
+6. `## Modifier / Field Model`
+7. `## Matching Notes`
+8. `## Open Gaps`
+
+## Claim Tags
+
+* [OBS] Directly observed in a local SASS dump, ptxas log, runtime output, or measured profile.
+* [INF] Inferred from controlled comparisons across observed variants.
+* [HYP] Plausible but not validated.
+* [RES] Resolved claim from prior observations or hypotheses.
+* [GAP] Missing or incomplete evidence.
+
+## Canonical Form Table
+
+Use this table shape:
+
+| Key | Distilled form | Meaning | Why it matters | Evidence | Notes |
+|---|---|---|---|---|---|
+| `FAMILY_OPERANDS_MODIFIERS` | `MNEMONIC operands` | Short literal description. | Short audit or matching relevance. | `path/to/file.sass` | [OBS] Short note. |
+
+## Field Model Table
+
+Use this table shape:
+
+| Field | Values observed | Evidence | Status |
+|---|---|---|---|
+| `shape` | `M88`, `MT88` | chapter paths | [OBS] Meaning. |
+
+## Rules
+
+* Do not include raw bit grids unless the bit placement is backed by local evidence or explicitly marked [GAP].
+* Prefer normalized keys that can become matcher signatures.
+* Add short literal explanations to tables that introduce an instruction, operand, field, or canonical form. The goal is glossary value, not long prose inside a table.
+* Separate target-specific claims (`sm_120` vs `sm_120a`).
+* Keep chapter-local narrative in `tensor_cores/*/conclusion*.md`; keep reusable matching facts here.

--- a/tensor_cores/README.md
+++ b/tensor_cores/README.md
@@ -37,9 +37,10 @@ Not in scope on SM120 (architecturally unavailable):
 | [19_sparse_mma/](./19_sparse_mma/) | 2:4 structured sparsity MMA | Sparse forms are `QMMA.SP`, `QMMA.SF.SP`, and `OMMA.SF.SP`; metadata is an explicit register operand |
 | [20_control_flow/](./20_control_flow/) | Control flow | Constant loops fully unroll by default; preserved loops expose back-edge BRA; 8 x 2 HMMA probe emits 16 HMMAs |
 | [21_divergence_reconvergence/](./21_divergence_reconvergence/) | Divergence and reconvergence | Lane divergence alone does not always force BSSY/BSYNC; ptxas also uses predication, FSEL/UFSEL, predicated EXIT, VOTE, WARPSYNC.ALL, and local CALL patterns |
-| 22_stmatrix/ | stmatrix / matrix store | Planned: STSM if present, fallback STS sequence if not present |
-| 23_fragment_layout/ | FP4 / FP6 fragment layout | Planned: E2M1, E3M2, E2M3 packing and runtime validation |
-| 24_production_mini_gemm/ | Production mini-GEMM audit | Planned: LDGSTS + LDSM + QMMA/OMMA + STG end-to-end |
+| [22_stmatrix/](./22_stmatrix/) | stmatrix / matrix store | STSM exists for m8n8 b16: `STSM.16.M[T]88[.2|.4]`; tested m16n8 b8 forms are target-qualified |
+| [23_fragment_layout/](./23_fragment_layout/) | FP4 / FP6 fragment layout | 22 probes: dense QMMA, LDSM-fed QMMA, scale-vector OMMA, sparse metadata; runtime smoke done, full decode open |
+| [24_production_mini_gemm/](./24_production_mini_gemm/) | Production mini-GEMM audit | 30 production-like probes: LDGSTS, LDSM, HMMA/QMMA/OMMA, STSM, STG, REDG, cold paths |
+| [25_stsm_epilogue/](./25_stsm_epilogue/) | STSM epilogue layout and storeback semantics | 26 probes: STSM layout, MMA epilogues, STS fallback, conversions, storeback, b8 compatibility |
 
 ## Phase 3 gate
 
@@ -49,12 +50,14 @@ Required before Phase 3:
 
 - [x] Chapter 20 - Control flow
 - [x] Chapter 21 - Divergence and reconvergence
-- [ ] Chapter 22 - stmatrix / matrix store
+- [x] Chapter 22 - stmatrix / matrix store
 
 Strongly recommended before Phase 3:
 
-- [ ] Chapter 23 - FP4 / FP6 fragment layout
-- [ ] Chapter 24 - Production mini-GEMM audit
+- [x] Chapter 23 - FP4 / FP6 fragment layout
+- [x] Chapter 24 - Production mini-GEMM audit
+- [x] Chapter 25 - STSM epilogue layout and storeback semantics
+- [ ] Audit confidence framework - methodology checklist for qualifying production-kernel conclusions
 
 Deferred and non-blocking for Phase 3:
 
@@ -68,11 +71,11 @@ Same controlled variation methodology as chapters 01-12. One minimal change per 
 
 Kernels use inline PTX `asm volatile` rather than CUTLASS wrappers to minimize compiler noise. CUTLASS wrappers may be used for comparison in specific variants.
 
-## Relationship with FINDINGS.md
+## Relationship with knowledge/
 
-Tensor core findings live in the main `FINDINGS.md` at the root of the repo, under dedicated `## Kernel <N>` sections. This is consistent with the project's principle of avoiding document proliferation: new opcodes extend the Pipelines table, new canonical patterns go in the Canonical patterns section, new architectural invariants go in Architectural invariants.
+Tensor core findings live in `../knowledge/FINDINGS.md`, under dedicated `## Kernel <N>` sections. Reusable instruction-family facts live in `../knowledge/SASS_INSTRUCTIONS_SM120.md` and `../knowledge/encoding/`.
 
-The per-chapter `conclusion{N}.md` files here document the narrative of the chapter (what we tried, in what order, what the deltas were). They complement but do not duplicate FINDINGS.md.
+The per-chapter `conclusion{N}.md` files here document the narrative of the chapter (what we tried, in what order, what the deltas were). They complement but do not duplicate the global knowledge files.
 
 ## Status
 
@@ -87,11 +90,12 @@ The per-chapter `conclusion{N}.md` files here document the narrative of the chap
 | 19 | **Done** | 19a-19m (13) | QMMA.SP.16864, QMMA.SF.SP.16864, OMMA.SF.SP.168128 |
 | 20 | **Done** | 20a-20v (22) | BRA, BRA.U, predication, BSSY/BSYNC for break |
 | 21 | **Done** | 21a-21t (20) | BSSY/BSYNC, VOTE.ANY, SHFL.IDX, WARPSYNC.ALL, predicated EXIT |
-| 22 | Planned | - | STSM or STS fallback |
-| 23 | Planned | - | FP4 / FP6 fragment packing |
-| 24 | Planned | - | Production mini-GEMM pattern |
+| 22 | **Done** | 22a-22l (12) | STSM.16.M88, STSM.16.MT88, STS.128 fallback |
+| 23 | **SASS + runtime smoke done** | 23a-23v (22) | QMMA.16832 FP4/FP6, QMMA.SF, OMMA.SF.4X, QMMA.SF.SP, LDSM-fed QMMA |
+| 24 | **SASS + runtime smoke done** | 24a-24ad (30) | LDGSTS, LDSM, HMMA/QMMA/OMMA, STSM, STG, REDG |
+| 25 | **SASS + runtime smoke done** | 25a-25z (26) | STSM.16.M88/MT88, STS.128, F2F.F16/BF16, MMA-to-STSM, STG |
 
-Chapters 13, 14, 16, 17, 18, and 19 decode the core tensor-core instruction families. Chapter 20 closes the first control-flow gate for loop lowering and back-edge detection. Chapter 21 closes the first divergence/reconvergence gate for the tested lane-divergent patterns. Chapters 22 through 24 remain required or strongly recommended before the pattern library because production audits also need matrix-store behavior, fragment layout, and an end-to-end mini-GEMM validation.
+Chapters 13, 14, 16, 17, 18, and 19 decode the core tensor-core instruction families. Chapter 20 closes the first control-flow gate for loop lowering and back-edge detection. Chapter 21 closes the first divergence/reconvergence gate for the tested lane-divergent patterns. Chapter 22 closes the first matrix-store gate for m8n8 b16 STSM. Chapter 23 closes first-pass FP4/FP6 SASS coverage and runtime smoke execution for fragment-layout probes, with full lane-to-value decode still open. Chapter 24 closes first-pass production-like mini-GEMM SASS coverage and runtime smoke execution, but remains structural rather than a full numeric GEMM correctness suite. Chapter 25 closes first-pass STSM epilogue/storeback SASS coverage and runtime smoke execution. The audit confidence framework remains open so production-kernel conclusions can be qualified explicitly.
 
 ## SM120 MMA opcode landscape (after chapter 19)
 


### PR DESCRIPTION
## Contribution type

Documentation and knowledge-base sync.

## Scope

This updates the public repository with the validated project documentation state:

- refresh the main README homepage;
- add the project logo asset;
- move global findings to `knowledge/FINDINGS.md`;
- add the knowledge-base index;
- add the SM120 / SM120a instruction glossary;
- add the ISA coverage tracker;
- add initial encoding pages for `LDSM`, `STSM`, and `QMMA`;
- update contribution and tensor-core documentation links.

## Reproducibility metadata

No new kernel or SASS experiment is introduced by this PR. The changes organize and publish existing validated documentation and knowledge-base content.

## Observed / inferred / hypothesis split

- [OBS] Existing project findings remain in `knowledge/FINDINGS.md` with their original claim tags.
- [INF] The README and index pages summarize current project structure and roadmap.
- [GAP] `knowledge/ISA_COVERAGE.md` marks non-observed instruction families as watchlist or gap items rather than local observations.

## Validation

- `git diff --check`
- Public-content guard for prohibited workflow/tooling terms across staged public-facing files returned no matches.
- `AGENTS.md` is not included.
- Copied project files were compared against the validated source tree.

## Open gaps

No new technical SASS gap is introduced by this documentation sync.